### PR TITLE
:bug: Fixes force unwrapping error

### DIFF
--- a/Example/Okta.xcodeproj/project.pbxproj
+++ b/Example/Okta.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		7137EDFB1EFDBFB40082C30F /* Okta_UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712745EC1EFB0B3F00E820FC /* Okta_UITests.swift */; };
 		7169AE1B1EF5EB8B00313EB8 /* Okta.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7169AE1A1EF5EB8B00313EB8 /* Okta.plist */; };
 		7169AE1E1EF5F27200313EB8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
+		7173E8391F97F10D008BC82A /* Okta-PasswordFlow.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7173E8381F97F10D008BC82A /* Okta-PasswordFlow.plist */; };
 		71F76E51BDB207F788887141 /* Pods_Okta_UITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4DF4896AAAB9BD5CAE67A8F /* Pods_Okta_UITests.framework */; };
 		E5E32C428E4371BB3E148847 /* Pods_Okta_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29991E729AD593DD12330109 /* Pods_Okta_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -63,6 +64,7 @@
 		7137EDEF1EFB25670082C30F /* Okta_UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Okta_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7137EDF91EFB281A0082C30F /* AppAuth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppAuth.framework; path = "../../Library/Developer/Xcode/DerivedData/Okta-auwqmzndabniaoghxgdrvwhlmgvr/Build/Products/Debug-iphonesimulator/AppAuth/AppAuth.framework"; sourceTree = "<group>"; };
 		7169AE1A1EF5EB8B00313EB8 /* Okta.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Okta.plist; sourceTree = "<group>"; };
+		7173E8381F97F10D008BC82A /* Okta-PasswordFlow.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Okta-PasswordFlow.plist"; sourceTree = "<group>"; };
 		A40CCA2C6BE208FDEDEA0B7A /* Pods-Okta_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_Tests/Pods-Okta_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		A4D59B5275951E9231367D12 /* Pods-Okta_UITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_UITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_UITests/Pods-Okta_UITests.debug.xcconfig"; sourceTree = "<group>"; };
 		A4DF4896AAAB9BD5CAE67A8F /* Pods_Okta_UITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Okta_UITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -147,6 +149,7 @@
 			children = (
 				607FACD41AFB9204008FA782 /* Info.plist */,
 				7169AE1A1EF5EB8B00313EB8 /* Okta.plist */,
+				7173E8381F97F10D008BC82A /* Okta-PasswordFlow.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -336,6 +339,7 @@
 			files = (
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
+				7173E8391F97F10D008BC82A /* Okta-PasswordFlow.plist in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 				7169AE1B1EF5EB8B00313EB8 /* Okta.plist in Resources */,
 			);
@@ -370,7 +374,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		03757DFC3F737ADF6576BF26 /* [CP] Embed Pods Frameworks */ = {
@@ -429,7 +433,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "";
 		};
 		77CEEB599872779C0A7813D4 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -458,7 +462,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		BE4A6B763053DCD47F9983C9 /* [CP] Copy Pods Resources */ = {
@@ -488,7 +492,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		FFF89B36345F569D99AA8E26 /* [CP] Copy Pods Resources */ = {

--- a/Example/Okta/Okta-PasswordFlow.plist
+++ b/Example/Okta/Okta-PasswordFlow.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>scopes</key>
+        <array>
+            <string>offline_access</string>
+            <string>openid</string>
+            <string>profile</string>
+        </array>
+        <key>redirectUri</key>
+        <string>com.okta.example:/callback</string>
+        <key>clientSecret</key>
+        <string>aaaaabbbbbccccc</string>
+        <key>clientId</key>
+        <string>GJv1mKQtUAUbTalBeQLs</string>
+        <key>issuer</key>
+        <string>https://example.oktapreview.com</string>
+    </dict>
+</plist>
+

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -45,12 +45,24 @@ class Tests: XCTestCase {
 
     func testPasswordFailureFlow() {
         // Validate the username & password flow fails without clientSecret
+        _ = Utils().getPlistConfiguration(forResourceName: "Okta-PasswordFlow")
+
+        let pwdExpectation = expectation(description: "Will error attempting username/password auth")
+
         OktaAuth
             .login("user@example.com", password: "password")
-            .start(UIViewController()) { response, error in
-                XCTAssertNotNil(error)
-                XCTAssertNil(response)
+            .start(withPListConfig: "Okta-PasswordFlow", view: UIViewController()) { response, error in
+
+                if error!.localizedDescription.range(of: "The operation couldn’t be completed") != nil {
+                    XCTAssertTrue(true)
+                }
+                pwdExpectation.fulfill()
         }
+
+        waitForExpectations(timeout: 20, handler: { error in
+            // Fail on timeout
+            if error != nil { XCTAssertNotNil(nil) }
+       })
     }
 
     func testKeychainStorage() {

--- a/Okta/OktaAuth.swift
+++ b/Okta/OktaAuth.swift
@@ -18,8 +18,7 @@ public struct OktaAuthorization {
                       callback: @escaping (OktaTokenManager?, OktaError?) -> Void) {
         
         // Discover Endpoints
-        getMetadataConfig(URL(string: config["issuer"] as! String)) {
-            oidConfig, error in
+        getMetadataConfig(URL(string: config["issuer"] as! String)) { oidConfig, error in
 
             if error != nil {
                 callback(nil, error!)
@@ -54,9 +53,8 @@ public struct OktaAuthorization {
                       callback: @escaping (OktaTokenManager?, OktaError?) -> Void) {
         
         // Discover Endpoints
-        getMetadataConfig(URL(string: config["issuer"] as! String)) {
-            oidConfig, error in
-            
+        getMetadataConfig(URL(string: config["issuer"] as! String)) { oidConfig, error in
+
             if error != nil {
                 callback(nil, error!)
                 return
@@ -75,11 +73,14 @@ public struct OktaAuthorization {
                             codeVerifier: nil,
                     additionalParameters: credentials
                 )
-            
+
             // Start the authorization flow
-            OIDAuthorizationService.perform(request) {
-                authorizationResponse, responseError in
-                
+            OIDAuthorizationService.perform(request) { authorizationResponse, responseError in
+
+                if responseError != nil {
+                    callback(nil, .apiError(error: "Authorization Error: \(responseError!.localizedDescription)"))
+                }
+
                 if authorizationResponse != nil {
                     // Return the tokens
                     let authState = OIDAuthState(
@@ -88,20 +89,16 @@ public struct OktaAuthorization {
                              registrationResponse: nil
                         )
                     callback(OktaTokenManager(authState: authState), nil)
-                } else {
-                    callback(nil, .apiError(error: "Authorization Error: \(error!.localizedDescription)"))
                 }
             }
-            
         }
     }
-    
+
     func getMetadataConfig(_ issuer: URL?, callback: @escaping (OIDServiceConfiguration?, OktaError?) -> Void) {
         // Get the metadata from the discovery endpoint
-        
-        OIDAuthorizationService.discoverConfiguration(forIssuer: issuer!) {
-            oidConfig, error in
-            
+
+        OIDAuthorizationService.discoverConfiguration(forIssuer: issuer!) { oidConfig, error in
+
             var configError: OktaError?
 
             if oidConfig == nil {
@@ -109,10 +106,11 @@ public struct OktaAuthorization {
                     "Error returning discovery document:" +
                     "\(error!.localizedDescription) Please" +
                     "check your PList configuration"
-                
+
                 configError = .apiError(error: responseError)
             }
             callback(oidConfig, configError)
+            return
         }
     }
 }

--- a/Okta/OktaLogin.swift
+++ b/Okta/OktaLogin.swift
@@ -47,7 +47,14 @@ public struct Login {
             if let config = Utils().getPlistConfiguration(forResourceName: plistName!) {
                 // Verify the ClientSecret was included
                 if (config["clientSecret"] as! String) == "" {
-                    callback(nil, .error(error: "ClientSecret not included in PList configuration file: \(plistName!) See https://github.com/okta/okta-sdk-appauth-ios/#configuration for more information." ))
+                    callback(
+                        nil,
+                        .error(
+                            error:  "ClientSecret not included in PList configuration file: "
+                            + "\(plistName!) See https://github.com/okta/okta-sdk-appauth-ios/#configuration"
+                            + "for more information."
+                        )
+                    )
                     return
                 }
                 if self.username == nil || self.password == nil {
@@ -58,7 +65,7 @@ public struct Login {
                 let credentials = [
                     "username": self.username!,
                     "password": self.password!
-                    ]
+                ]
 
                 OktaAuthorization().passwordFlow(config, credentials: credentials, view: view) { response, error in callback(response, error) }
             }


### PR DESCRIPTION
- During the resource owner password flow, if the invalid credentials are included - we currently return a force-unwrapped "error". This error should be the local error, not the parent error.

Resolves: OKTA-144867