### PR TITLE
Adds helper method for determining + resuming the authState

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: objective-c
-osx_image: xcode9.1
-
+osx_image: xcode9.2
 before_install:
-  - rvm install ruby-2.2.0
+  - rvm install ruby-2.3.1
   - gem install cocoapods
+  - gem install xcpretty
 script:
   - bash ./scripts/build-and-test.sh

--- a/Example/Okta.xcodeproj/xcshareddata/xcschemes/Okta-Example.xcscheme
+++ b/Example/Okta.xcodeproj/xcshareddata/xcschemes/Okta-Example.xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -79,6 +80,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -95,6 +97,18 @@
             ReferencedContainer = "container:Okta.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "USERNAME"
+            value = "$(USERNAME)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "PASSWORD"
+            value = "$(PASSWORD)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Example/Okta/Okta.plist
+++ b/Example/Okta/Okta.plist
@@ -9,8 +9,8 @@
 	<key>clientSecret</key>
 	<string></string>
 	<key>clientId</key>
-	<string>{clientId}</string>
+	<string>0oae1enia6od2nlz00h7</string>
 	<key>issuer</key>
-	<string>https://{yourOktaDomain}.com/oauth2/default</string>
+	<string>https://demo-org.oktapreview.com/oauth2/default</string>
 </dict>
 </plist>

--- a/Example/Okta/ViewController.swift
+++ b/Example/Okta/ViewController.swift
@@ -13,10 +13,17 @@ class ViewController: UIViewController {
 
     @IBOutlet weak var tokenView: UITextView!
 
-    override func viewDidLoad() { super.viewDidLoad() }
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if OktaAuth.isAuthenticated() {
+            // If there is a valid accessToken
+            // build the token view.
+            self.buildTokenTextView()
+        }
+    }
 
     @IBAction func loginButton(_ sender: Any) {
-        if tokens == nil { self.loginCodeFlow() }
+        self.loginCodeFlow()
     }
 
     @IBAction func clearTokens(_ sender: Any) {
@@ -56,11 +63,7 @@ class ViewController: UIViewController {
 
     func loginCodeFlow() {
         OktaAuth.login().start(self)
-        .then { authResponse in
-            tokens?.set(value: authResponse.accessToken!, forKey: "accessToken")
-            tokens?.set(value: authResponse.idToken!, forKey: "idToken")
-            self.buildTokenTextView()
-        }
+        .then { _ in self.buildTokenTextView() }
         .catch { error in print(error) }
     }
 
@@ -69,23 +72,22 @@ class ViewController: UIViewController {
     }
 
     func buildTokenTextView() {
-        if tokens == nil {
+        guard let currentTokens = tokens else {
             tokenView.text = ""
             return
         }
 
         var tokenString = ""
-
-        if let accessToken = tokens?.accessToken {
+        if let accessToken = currentTokens.accessToken {
             tokenString += ("\nAccess Token: \(accessToken)\n")
         }
 
-        if let idToken = tokens?.idToken {
-            tokenString += "\nidToken Token: \(idToken)\n"
+        if let idToken = currentTokens.idToken {
+            tokenString += "\nID Token: \(idToken)\n"
         }
 
-        if let refreshToken = tokens?.refreshToken {
-            tokenString += "\nrefresh Token: \(refreshToken)\n"
+        if let refreshToken = currentTokens.refreshToken {
+            tokenString += "\nRefresh Token: \(refreshToken)\n"
         }
 
         self.updateUI(updateText: tokenString)

--- a/Example/Okta_UITests/Okta_UITests.swift
+++ b/Example/Okta_UITests/Okta_UITests.swift
@@ -15,8 +15,8 @@ import OktaAuth
 
 class OktaUITests: XCTestCase {
     // Update these values along with your Plist config
-    var username = "{username}"
-    var password = "{password}"
+    var username = ProcessInfo.processInfo.environment["USERNAME"]!
+    var password = ProcessInfo.processInfo.environment["PASSWORD"]!
 
     var testUtils: UITestUtils?
     let app = XCUIApplication()
@@ -25,7 +25,7 @@ class OktaUITests: XCTestCase {
         super.setUp()
         testUtils = UITestUtils(app)
 
-        continueAfterFailure = false
+        continueAfterFailure = true
         XCUIApplication().launch()
     }
 
@@ -46,6 +46,7 @@ class OktaUITests: XCTestCase {
         // Wait for browser to load
         // This sleep bypasses the need to "click" the consent for Safari
         sleep(2)
+        app.tap()
 
         // Login
         testUtils.login(username: username, password: password)
@@ -59,7 +60,7 @@ class OktaUITests: XCTestCase {
     func testAuthCodeFlow() {
         loginAndWait()
 
-        let tokenValues = testUtils?.getTextViewValue(label: "tokenView")
+        let tokenValues = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertNotNil(tokenValues)
     }
 
@@ -69,7 +70,7 @@ class OktaUITests: XCTestCase {
         // Get User info
         app.buttons["GetUser"].tap()
 
-        let userInfoValue = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 2)
+        let userInfoValue = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertTrue(userInfoValue!.contains(username))
     }
 
@@ -79,19 +80,23 @@ class OktaUITests: XCTestCase {
         // Introspect Valid Token
         app.buttons["Introspect"].tap()
 
-        let valid = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 2)
+        let valid = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertTrue(valid!.contains("true"))
+    }
+
+    func testAuthCodeFlowRevokeAndIntrospect() {
+        loginAndWait()
 
         // Revoke Token
         app.buttons["Revoke"].tap()
 
-        let revoked = testUtils?.getTextViewValue(label: "tokenView")
+        let revoked = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertTrue(revoked!.contains("AccessToken was revoked"))
 
         // Introspect invalid Token
         app.buttons["Introspect"].tap()
 
-        let isNotValid = testUtils?.getTextViewValue(label: "tokenView")
+        let isNotValid = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertTrue(isNotValid!.contains("false"))
 
         // Clear all tokens

--- a/Example/Okta_UITests/Okta_UITests.swift
+++ b/Example/Okta_UITests/Okta_UITests.swift
@@ -46,6 +46,9 @@ class OktaUITests: XCTestCase {
         // Wait for browser to load
         // This sleep bypasses the need to "click" the consent for Safari
         sleep(2)
+        
+        // Known bug with iOS 11 and system alerts (need to tap twice)
+        app.tap()
         app.tap()
 
         // Login

--- a/Example/Okta_UITests/Okta_UITests.swift
+++ b/Example/Okta_UITests/Okta_UITests.swift
@@ -14,15 +14,16 @@ import XCTest
 import OktaAuth
 
 class OktaUITests: XCTestCase {
-    var username = ""
-    var password = ""
+    // Update these values along with your Plist config
+    var username = "{username}"
+    var password = "{password}"
+
+    var testUtils: UITestUtils?
+    let app = XCUIApplication()
 
     override func setUp() {
         super.setUp()
-
-        // Update these values along with your Plist config
-        username = "{username}"
-        password = "{password}"
+        testUtils = UITestUtils(app)
 
         continueAfterFailure = false
         XCUIApplication().launch()
@@ -32,9 +33,13 @@ class OktaUITests: XCTestCase {
         super.tearDown()
     }
 
-    func testAuthorizationCodeFlow() {
-        let app = XCUIApplication()
-        let testUtils = UITestUtils(app)
+    func loginAndWait() {
+        guard let testUtils = testUtils else { return }
+
+        // Check to see if there are tokens displayed (indicating an authenticated state)
+        if let tokens = testUtils.getTextViewValue(label: "tokenView"), tokens.contains("Access Token") {
+            return
+        }
 
         app.buttons["Login"].tap()
 
@@ -45,42 +50,51 @@ class OktaUITests: XCTestCase {
         // Login
         testUtils.login(username: username, password: password)
 
-        // Wait for app to redirect back (Granting 3 second delay)
-        if !testUtils.waitForElement(app.textViews["tokenView"], timeout: 3) {
+        // Wait for app to redirect back (Granting 5 second delay)
+        if !testUtils.waitForElement(app.textViews["tokenView"], timeout: 5) {
             XCTFail("Unable to redirect back from browser")
         }
+    }
 
-        let tokenValues = testUtils.getTextViewValue(label: "tokenView")
+    func testAuthCodeFlow() {
+        loginAndWait()
+
+        let tokenValues = testUtils?.getTextViewValue(label: "tokenView")
         XCTAssertNotNil(tokenValues)
+    }
+
+    func testAuthCodeFlowAndUserInfo(){
+        loginAndWait()
 
         // Get User info
         app.buttons["GetUser"].tap()
 
-        let userInfoValue = testUtils.getTextViewValue(label: "tokenView")
+        let userInfoValue = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 2)
         XCTAssertTrue(userInfoValue!.contains(username))
+    }
+
+    func testAuthCodeFlowIntrospectAndRevoke() {
+        loginAndWait()
 
         // Introspect Valid Token
         app.buttons["Introspect"].tap()
 
-        let valid = testUtils.getTextViewValue(label: "tokenView")
+        let valid = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 2)
         XCTAssertTrue(valid!.contains("true"))
 
         // Revoke Token
         app.buttons["Revoke"].tap()
 
-        let revoked = testUtils.getTextViewValue(label: "tokenView")
+        let revoked = testUtils?.getTextViewValue(label: "tokenView")
         XCTAssertTrue(revoked!.contains("AccessToken was revoked"))
 
         // Introspect invalid Token
         app.buttons["Introspect"].tap()
 
-        let isNotValid = testUtils.getTextViewValue(label: "tokenView")
+        let isNotValid = testUtils?.getTextViewValue(label: "tokenView")
         XCTAssertTrue(isNotValid!.contains("false"))
 
-        // Clear Tokens
+        // Clear all tokens
         app.buttons["Clear"].tap()
-
-        let val = testUtils.getTextViewValue(label: "tokenView")
-        XCTAssertEqual(val!, "")
     }
 }

--- a/Example/Okta_UITests/UITestUtils.swift
+++ b/Example/Okta_UITests/UITestUtils.swift
@@ -19,6 +19,8 @@ public struct UITestUtils {
     }
 
     func login(username: String, password: String) {
+        sleep(2)
+
         // Login via username and password inside of the Safari WebView
         let webViewsQuery = testApp.webViews
         let usernameField = webViewsQuery.textFields["Username"]

--- a/Example/Okta_UITests/UITestUtils.swift
+++ b/Example/Okta_UITests/UITestUtils.swift
@@ -19,8 +19,6 @@ public struct UITestUtils {
     }
 
     func login(username: String, password: String) {
-        sleep(2)
-
         // Login via username and password inside of the Safari WebView
         let webViewsQuery = testApp.webViews
         let usernameField = webViewsQuery.textFields["Username"]

--- a/Example/Okta_UITests/UITestUtils.swift
+++ b/Example/Okta_UITests/UITestUtils.swift
@@ -24,6 +24,10 @@ public struct UITestUtils {
         let usernameField = webViewsQuery.textFields["Username"]
         let passwordField = webViewsQuery.secureTextFields["Password"]
 
+        if !waitForElement(usernameField, timeout: 10) && waitForElement(passwordField, timeout: 10) {
+            return
+        }
+
         usernameField.tap()
         usernameField.typeText(username)
         passwordField.tap()

--- a/Example/Okta_UITests/UITestUtils.swift
+++ b/Example/Okta_UITests/UITestUtils.swift
@@ -39,6 +39,12 @@ public struct UITestUtils {
         return nil
     }
 
+    func getTextViewValueWithDelay(label: String, delay: UInt32) -> String? {
+        // Returns the value of a textView after a given delay
+        sleep(delay)
+        return getTextViewValue(label: label)
+    }
+
     func waitForElement(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
         // Generic wait for element to apepar function w/ timeout
         let pred = NSPredicate(format: "exists == true")

--- a/Okta/OktaAppAuth.swift
+++ b/Okta/OktaAppAuth.swift
@@ -11,6 +11,7 @@
  */
 
 import AppAuth
+import Vinculum
 
 // Current version of the SDK
 let VERSION = "0.3.0"
@@ -35,6 +36,24 @@ public func login(_ username: String, password: String) -> Login {
 public func login() -> Login {
     // Authenticate via authorization code flow
     return Login()
+}
+
+public func isAuthenticated() -> Bool {
+    // Restore state
+    guard let encodedAuthStateItem = try? Vinculum.get("OktaAuthStateTokenManager"),
+        let encodedAuthState = encodedAuthStateItem else {
+        return false
+    }
+
+    guard let previousState = NSKeyedUnarchiver
+        .unarchiveObject(with: encodedAuthState.value) as? OktaTokenManager else { return false }
+
+    tokens = previousState
+
+    if tokens?.accessToken != nil {
+        return true
+    }
+    return false
 }
 
 public func introspect() -> Introspect {

--- a/Okta/OktaRefresh.swift
+++ b/Okta/OktaRefresh.swift
@@ -20,8 +20,8 @@ internal struct Refresh {
                 return reject(OktaError.NoRefreshToken)
             }
 
-            tokens?.authState?.setNeedsTokenRefresh()
-            tokens?.authState?.performAction(freshTokens: { accessToken, idToken, error in
+            tokens?.authState.setNeedsTokenRefresh()
+            tokens?.authState.performAction(freshTokens: { accessToken, idToken, error in
                 if error != nil {
                     return reject(OktaError.ErrorFetchingFreshTokens(error!.localizedDescription))
                 }

--- a/Okta/OktaTokenManager.swift
+++ b/Okta/OktaTokenManager.swift
@@ -15,26 +15,30 @@ import Vinculum
 
 open class OktaTokenManager: NSObject, NSCoding {
 
-    private var _idToken: String? = nil
+    internal var _idToken: String? = nil
 
     open var authState: OIDAuthState
     open var config: [String: String]
     open var accessibility: CFString
 
-    open var idToken: String? {
-        get { return self._idToken }
-    }
-
-    open var refreshToken: String? {
+    open var accessToken: String? {
+        // Return the known accessToken
         get {
-            guard let token = self.authState.refreshToken else { return nil }
+            guard let token = self.authState.lastTokenResponse?.accessToken else { return nil }
             return token
         }
     }
 
-    open var accessToken: String? {
+    open var idToken: String? {
+        // Return the known idToken via the internal _idToken var
+        // since it gets lost on refresh
+        get { return self._idToken }
+    }
+
+    open var refreshToken: String? {
+        // Return the known refreshToken
         get {
-            guard let token = self.authState.lastTokenResponse?.accessToken else { return nil }
+            guard let token = self.authState.refreshToken else { return nil }
             return token
         }
     }

--- a/Okta/OktaUserInfo.swift
+++ b/Okta/OktaUserInfo.swift
@@ -18,7 +18,7 @@ internal struct UserInfo {
             callback(nil, .NoUserInfoEndpoint)
             return
         }
-
+        
         guard let token = token else {
             callback(nil, .NoBearerToken)
             return

--- a/Okta/OktaUserInfo.swift
+++ b/Okta/OktaUserInfo.swift
@@ -18,7 +18,7 @@ internal struct UserInfo {
             callback(nil, .NoUserInfoEndpoint)
             return
         }
-        
+
         guard let token = token else {
             callback(nil, .NoBearerToken)
             return

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -12,14 +12,14 @@ fi
 
 echo "- Starting tests..."
 
-if ! build_and_run_unit_tests "$USERNAME" "$PASSWORD"; then
-    exit 1
-else
-  echo -e "\xE2\x9C\x94 Passed Unit tests"
-fi
-
 if ! build_and_run_ui_tests "$USERNAME" "$PASSWORD"; then
     exit 1
 else
   echo -e "\xE2\x9C\x94 Passed UI tests"
+fi
+
+if ! build_and_run_unit_tests; then
+    exit 1
+else
+  echo -e "\xE2\x9C\x94 Passed Unit tests"
 fi

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -1,33 +1,25 @@
 #!/bin/bash
+source "${0%/*}/helpers.sh"
 
 set -e
 
 # Go to correct path for install
 cd Example
 
-
-function pod_install() {
-    echo "==== Installing pods ===="
-    pod install --repo-update
-}
-
-if ! pod_install; then
+if ! pod_dependencies; then
     exit 1
 fi
 
-function build_and_test_workspace() {
-    echo "*******************"
-    echo "Building Workspace"
-    echo "*******************"
-    xcodebuild test \
-    -workspace Okta.xcworkspace/ \
-    -scheme Okta-Example \
-    -destination 'platform=iOS Simulator,OS=11.1,name=iPhone 8' \
-    -only-testing:Okta_Tests
-}
+echo "- Starting tests..."
 
-if ! build_and_test_workspace; then
+if ! build_and_run_unit_tests "$USERNAME" "$PASSWORD"; then
     exit 1
+else
+  echo -e "\xE2\x9C\x94 Passed Unit tests"
 fi
 
-echo "All tests passed"
+if ! build_and_run_ui_tests "$USERNAME" "$PASSWORD"; then
+    exit 1
+else
+  echo -e "\xE2\x9C\x94 Passed UI tests"
+fi

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Set workspace
+WORKSPACE="Okta.xcworkspace/"
+
+# Set scheme
+SCHEME="Okta-Example"
+
+# Set test devices
+IPHONE_8_DESTINATION="OS=11.2,name=iPhone X"
+
+pod_dependencies () {
+    echo "- Installing dependencies"
+    echo "└─  Installing pods"
+    pod install --repo-update --silent
+}
+
+build_and_run_unit_tests () {
+    remove_simulator_data
+
+    echo "└─  Starting Unit Tests"
+
+    set -o pipefail && xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
+    -destination "$IPHONE_8_DESTINATION" \
+    -only-testing:Okta_Tests \
+    USERNAME="$1" PASSWORD="$2" test | xcpretty;
+}
+
+build_and_run_ui_tests () {
+    remove_simulator_data
+    
+    echo "└─  Starting UI Tests"
+    
+    set -o pipefail && xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
+    -destination "$IPHONE_8_DESTINATION" \
+    -only-testing:Okta_UITests \
+    USERNAME="$1" PASSWORD="$2" test | xcpretty;
+}
+
+remove_simulator_data () {
+    echo "└─  Removing Simulator Data"
+    xcrun simctl erase all
+}

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -22,8 +22,7 @@ build_and_run_unit_tests () {
 
     set -o pipefail && xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
     -destination "$IPHONE_X_DESTINATION" \
-    -only-testing:Okta_Tests \
-    USERNAME="$1" PASSWORD="$2" test | xcpretty;
+    -only-testing:Okta_Tests test | xcpretty;
 }
 
 build_and_run_ui_tests () {

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -7,7 +7,7 @@ WORKSPACE="Okta.xcworkspace/"
 SCHEME="Okta-Example"
 
 # Set test devices
-IPHONE_8_DESTINATION="OS=11.2,name=iPhone X"
+IPHONE_X_DESTINATION="OS=11.2,name=iPhone X"
 
 pod_dependencies () {
     echo "- Installing dependencies"
@@ -21,7 +21,7 @@ build_and_run_unit_tests () {
     echo "└─  Starting Unit Tests"
 
     set -o pipefail && xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
-    -destination "$IPHONE_8_DESTINATION" \
+    -destination "$IPHONE_X_DESTINATION" \
     -only-testing:Okta_Tests \
     USERNAME="$1" PASSWORD="$2" test | xcpretty;
 }
@@ -32,7 +32,7 @@ build_and_run_ui_tests () {
     echo "└─  Starting UI Tests"
     
     set -o pipefail && xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
-    -destination "$IPHONE_8_DESTINATION" \
+    -destination "$IPHONE_X_DESTINATION" \
     -only-testing:Okta_UITests \
     USERNAME="$1" PASSWORD="$2" test | xcpretty;
 }


### PR DESCRIPTION
Allows the ability to easily manage user state on app setup. The method `isAuthenticated()` checks for an `accessToken` and `idToken` stored in the Keychain. If available, it will attempt to deserialize the last `authState` response to resume the user's state.

```swift
// ViewController.swift
override func viewDidLoad() {
    ...
    if !OktaAuth.isAuthenticated() {
        // Start the login flow
    }
}
```

Resolves: [OKTA-153412](https://oktainc.atlassian.net/browse/OKTA-153412) and #21 