### PR TITLE
:bug: Fixed issue where URLs were malformed

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -106,4 +106,22 @@ class Tests: XCTestCase {
         tokens.clear()
         XCTAssertNil(tokens.get(forKey: "accessToken"))
     }
+
+    func testIntrospectionEndpointURL() {
+        // Similar use case for revoke and userinfo endpoints
+        OktaAuth.configuration = [
+            "issuer": "https://example.com"
+        ]
+        let url = Introspect().getIntrospectionEndpoint()
+        XCTAssertEqual(url?.absoluteString, "https://example.com/oauth2/v1/introspect")
+    }
+
+    func testIntrospectionEndpointURLWithOAuth2() {
+        // Similar use case for revoke and userinfo endpoints
+        OktaAuth.configuration = [
+            "issuer": "https://example.com/oauth2/default"
+        ]
+        let url = Introspect().getIntrospectionEndpoint()
+        XCTAssertEqual(url?.absoluteString, "https://example.com/oauth2/default/v1/introspect")
+    }
 }

--- a/Okta/OktaIntrospection.swift
+++ b/Okta/OktaIntrospection.swift
@@ -39,6 +39,9 @@ public struct Introspect {
         }
 
         let issuer = OktaAuth.configuration?["issuer"] as! String
+        if issuer.range(of: "oauth2") != nil {
+            return URL(string: Utils.removeTrailingSlash(issuer) + "/v1/introspect")
+        }
         return URL(string: Utils.removeTrailingSlash(issuer) + "/oauth2/v1/introspect")
     }
 }

--- a/Okta/OktaRevoke.swift
+++ b/Okta/OktaRevoke.swift
@@ -44,6 +44,9 @@ public struct Revoke {
         }
 
         let issuer = OktaAuth.configuration?["issuer"] as! String
+        if issuer.range(of: "oauth2") != nil {
+            return URL(string: Utils.removeTrailingSlash(issuer) + "/v1/revoke")
+        }
         return URL(string: Utils.removeTrailingSlash(issuer) + "/oauth2/v1/revoke")
     }
 }

--- a/Okta/OktaUserInfo.swift
+++ b/Okta/OktaUserInfo.swift
@@ -43,6 +43,9 @@ public struct UserInfo {
         }
 
         let issuer = OktaAuth.configuration?["issuer"] as! String
+        if issuer.range(of: "oauth2") != nil {
+            return URL(string: Utils.removeTrailingSlash(issuer) + "/v1/userinfo")
+        }
         return URL(string: Utils.removeTrailingSlash(issuer) + "/oauth2/v1/userinfo")
     }
 }


### PR DESCRIPTION
When **not** using the `well-known` discovery metadata, we were expecting URLs to be in the format: `https://org.com/oauth2/authServerId`.

This **fix** is to detect when using a custom AS or default AS.