### PR TITLE
:seedling: Adds ability to pass additionalParams to the /authorize

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -41,7 +41,7 @@ class Tests: XCTestCase {
         XCTAssertEqual(issuer, "https://example.com/oauth2/authServerId")
     }
 
-    func testAdditionParamParse() {
+    func testAdditionalParamParse() {
         // Ensure known values from the config object are removed
         let config = [
             "issuer": "https://example.com/oauth2/default",
@@ -59,7 +59,7 @@ class Tests: XCTestCase {
         XCTAssertNotNil(additionalParams?["nonce"])
     }
 
-    func testAdditionParamParseWithNoChange() {
+    func testAdditionalParamParseWithNoChange() {
         // Ensure known values from the config object are removed
         let config = [  "nonce": "abbbbbbbc" ]
 

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -41,6 +41,33 @@ class Tests: XCTestCase {
         XCTAssertEqual(issuer, "https://example.com/oauth2/authServerId")
     }
 
+    func testAdditionParamParse() {
+        // Ensure known values from the config object are removed
+        let config = [
+            "issuer": "https://example.com/oauth2/default",
+            "clientId": "clientId",
+            "redirectUri": "com.okta.example:/callback",
+            "scopes": "openid profile offline_access",
+            "nonce": "abbbbbbbc"
+        ]
+
+        let additionalParams = Utils.parseAdditionalParams(config)
+        XCTAssertNil(additionalParams?["issuer"])
+        XCTAssertNil(additionalParams?["clientId"])
+        XCTAssertNil(additionalParams?["redirectUri"])
+        XCTAssertNil(additionalParams?["scopes"])
+        XCTAssertNotNil(additionalParams?["nonce"])
+    }
+
+    func testAdditionParamParseWithNoChange() {
+        // Ensure known values from the config object are removed
+        let config = [  "nonce": "abbbbbbbc" ]
+
+        let additionalParams = Utils.parseAdditionalParams(config)
+        XCTAssertNotNil(additionalParams?["nonce"])
+        XCTAssertEqual(config, additionalParams!)
+    }
+
     func testValidScopesString() {
         // Validate the scopes are in the correct format
         let scopes = "openid profile email"

--- a/Okta/OktaApi.swift
+++ b/Okta/OktaApi.swift
@@ -12,7 +12,20 @@
 import Hydra
 
 open class OktaApi: NSObject {
-    class func post(_ url: URL, headers: [String: String]?, postData: String?) -> Promise<[String: Any]?> {
+
+    class func post(_ url: URL, headers: [String: String]?, postString: String?) -> Promise<[String: Any]?> {
+        // Generic POST API wrapper for data passed in as a String
+        let data = postString != nil ? postString!.data(using: .utf8) : nil
+        return OktaApi.post(url, headers: headers, postData: data)
+    }
+
+    class func post(_ url: URL, headers: [String: String]?, postJson: [String: Any]?) -> Promise<[String: Any]?> {
+        // Generic POST API wrapper for data passed in as a JSON object [String: Any]
+        let data = postJson != nil ? try? JSONSerialization.data(withJSONObject: postJson as Any, options: []) : nil
+        return OktaApi.post(url, headers: headers, postData: data)
+    }
+
+    class func post(_ url: URL, headers: [String: String]?, postData: Data?) -> Promise<[String: Any]?> {
         // Generic POST API wrapper
         return Promise<[String: Any]?>(in: .background, { resolve, reject, _ in
             var request = URLRequest(url: url)
@@ -24,7 +37,7 @@ open class OktaApi: NSObject {
             )
 
             if let postBodyData = postData {
-                request.httpBody = postBodyData.data(using: .utf8)
+                request.httpBody = postBodyData
             }
 
             let task = URLSession.shared.dataTask(with: request){ data, response, error in

--- a/Okta/OktaAuth.swift
+++ b/Okta/OktaAuth.swift
@@ -32,7 +32,7 @@ public struct OktaAuthorization {
                                   scopes: Utils.scrubScopes(config["scopes"]),
                              redirectURL: URL(string: redirectUri)!,
                             responseType: OIDResponseTypeCode,
-                    additionalParameters: nil
+                    additionalParameters: Utils.parseAdditionalParams(config)
                 )
 
                 // Start the authorization flow

--- a/Okta/OktaIntrospection.swift
+++ b/Okta/OktaIntrospection.swift
@@ -28,7 +28,7 @@ public struct Introspect {
                 let data = "token=\(token)&client_id=\(OktaAuth.configuration?["clientId"] as! String)"
 
                 OktaApi
-                    .post(introspectionEndpoint, headers: headers, postData: data)
+                    .post(introspectionEndpoint, headers: headers, postString: data)
                     .then { response in
                         guard let isActive = response?["active"] as? Bool else {
                             return reject(OktaError.ParseFailure)

--- a/Okta/OktaLogin.swift
+++ b/Okta/OktaLogin.swift
@@ -31,6 +31,15 @@ public struct Login {
         self.passwordFlow = false
     }
 
+    public func start(withDictConfig dict: [String: String], view: UIViewController,
+                      callback: @escaping (OktaTokenManager?, OktaError?) -> Void) {
+
+        OktaAuth.configuration = dict
+        OktaAuthorization().authCodeFlow(dict, view)
+        .then { response in callback(response, nil) }
+        .catch { error in callback(nil, error as? OktaError) }
+    }
+
     public func start(withPListConfig plistName: String?, view: UIViewController,
                       callback: @escaping (OktaTokenManager?, OktaError?) -> Void) {
 

--- a/Okta/OktaRevoke.swift
+++ b/Okta/OktaRevoke.swift
@@ -28,7 +28,7 @@ public struct Revoke {
             let data = "token=\(self.token!)&client_id=\(OktaAuth.configuration?["clientId"] as! String)"
 
             OktaApi
-                .post(revokeEndpoint, headers: headers, postData: data)
+                .post(revokeEndpoint, headers: headers, postString: data)
                 .then { response in callback(response, nil) }
                 .catch { error in callback(nil, error as? OktaError) }
         } else {

--- a/Okta/OktaUtils.swift
+++ b/Okta/OktaUtils.swift
@@ -75,4 +75,16 @@ open class Utils: NSObject {
         // Removes the URLs trailing slash if it exists
         return String(val.suffix(1)) == "/" ? String(val.dropLast()) : val
     }
+
+    internal class func parseAdditionalParams(_ config: [String: String]) -> [String: String]? {
+        // Parse the additional parameters to be passed to the /authorization endpoint
+        var configCopy = config
+        
+        // Remove "issuer", "clientId", "redirectUri", and "scopes"
+        configCopy.removeValue(forKey: "issuer")
+        configCopy.removeValue(forKey: "clientId")
+        configCopy.removeValue(forKey: "redirectUri")
+        configCopy.removeValue(forKey: "scopes")
+        return configCopy
+    }
 }


### PR DESCRIPTION
- 🌱 Extends the ability to pass in optional parameters to the `/authorization` endpoint
- 🌱 Allows login to be kicked off using a `[String: String]` object instead of `.plist`

Resolves: #32 