### PR TITLE
:bug: Fix tokens not being refreshed when using ROPF

### DIFF
--- a/Example/Okta/Okta-PasswordFlow.plist
+++ b/Example/Okta/Okta-PasswordFlow.plist
@@ -9,8 +9,8 @@
 	<key>clientSecret</key>
 	<string>thisIsAFakeClientSecret</string>
 	<key>clientId</key>
-	<string>GJv1mKQtUAUbTalBeQLs</string>
+	<string>0oae9l99q4qJfG3rG0h7</string>
 	<key>issuer</key>
-	<string>https://example.oktapreview.com</string>
+	<string>https://demo-org.oktapreview.com/oauth2/default</string>
 </dict>
 </plist>

--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -14,6 +14,8 @@ import Hydra
 struct TestUtils {
     static let mockIssuer = "https://demo-org.oktapreview.com/oauth2/default"
     static let mockClientId = "0oae1enia6od2nlz00h7"
+    static let mockClientSecret = "clientSecret"
+    static let mockRedirectUri = "com.okta.example:/callback"
     static let mockScopes = "openid email"
 
     static let mockAccessToken = "abc.123.xyz"
@@ -68,7 +70,9 @@ struct TestUtils {
                     authState: tempAuthState,
                     config: [
                         "issuer": mockIssuer,
-                        "clientId": mockClientId
+                        "clientId": mockClientId,
+                        "clientSecret": mockClientSecret,
+                        "redirectUri": mockRedirectUri
                     ],
                     validationOptions: options
                 )

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -138,7 +138,6 @@ class Tests: XCTestCase {
         OktaAuth.configuration = [
             "issuer": "https://example.com/oauth2/default"
         ]
-
         let _ = Revoke(token: nil) { response, error in
             XCTAssertEqual(error?.localizedDescription, "Missing Bearer token. You must authenticate first.")
         }

--- a/Okta/OktaIntrospection.swift
+++ b/Okta/OktaIntrospection.swift
@@ -28,7 +28,13 @@ public struct Introspect {
                 "Content-Type": "application/x-www-form-urlencoded"
             ]
 
-            let data = "token=\(token)&client_id=\(OktaAuth.configuration?["clientId"] as! String)"
+            var data = "token=\(token)&client_id=\(OktaAuth.configuration?["clientId"] as! String)"
+
+            // Append the clientSecret if it exists
+            if let clientSecretObj = OktaAuth.configuration?["clientSecret"],
+                let clientSecret = clientSecretObj as? String {
+                    data += "&client_secret=\(clientSecret)"
+            }
 
             OktaApi.post(introspectionEndpoint, headers: headers, postString: data)
             .then { response in

--- a/Okta/OktaRevoke.swift
+++ b/Okta/OktaRevoke.swift
@@ -29,7 +29,13 @@ public struct Revoke {
             "Content-Type": "application/x-www-form-urlencoded"
         ]
 
-        let data = "token=\(token)&client_id=\(OktaAuth.configuration?["clientId"] as! String)"
+        var data = "token=\(token)&client_id=\(OktaAuth.configuration?["clientId"] as! String)"
+
+        // Append the clientSecret if it exists
+        if let clientSecretObj = OktaAuth.configuration?["clientSecret"],
+            let clientSecret = clientSecretObj as? String {
+            data += "&client_secret=\(clientSecret)"
+        }
 
         OktaApi.post(revokeEndpoint, headers: headers, postString: data)
         .then { response in callback(response, nil) }


### PR DESCRIPTION
When using the ROPF - tokens would not be refreshed due to the `lastAuthorizationResponse` always returning `nil`.

Tokens are now manually refreshed if there is no `lastAuthorizationResponse` attached to the current `authState` and a `refreshToken` is available.

