### PR TITLE
:seedling: Cache well-known for easy access

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -145,4 +145,27 @@ class Tests: XCTestCase {
         let url = Introspect().getIntrospectionEndpoint()
         XCTAssertEqual(url?.absoluteString, "https://example.com/oauth2/default/v1/introspect")
     }
+
+    func testUserInfoWithoutToken() {
+        // Verify an error is returned if the accessToken is not included
+        OktaAuth.configuration = [
+            "issuer": "https://example.com/oauth2/default"
+        ]
+
+        let _ = UserInfo(token: nil) { response, error in
+            XCTAssertEqual(error?.localizedDescription, "Missing Bearer token. You must authenticate first.")
+        }
+    }
+
+    func testRevokeWithoutToken() {
+        // Verify an error is returned if the accessToken is not included
+        OktaAuth.configuration = [
+            "issuer": "https://example.com/oauth2/default"
+        ]
+
+        let _ = Revoke(token: nil) { response, error in
+            XCTAssertEqual(error?.localizedDescription, "Missing Bearer token. You must authenticate first.")
+        }
+    }
+
 }

--- a/Okta/OktaAppAuth.swift
+++ b/Okta/OktaAppAuth.swift
@@ -21,6 +21,9 @@ public var currentAuthorizationFlow: OIDAuthorizationFlowSession?
 // Cache Okta.plist for reference
 public var configuration: [String: Any]?
 
+// Cache the Discovery Metadata
+public var wellKnown: [String: Any]?
+
 // Token manager
 public var tokens: OktaTokenManager?
 

--- a/Okta/OktaAuth.swift
+++ b/Okta/OktaAuth.swift
@@ -110,6 +110,9 @@ public struct OktaAuthorization {
                 guard let dictResponse = response, let oidcConfig = try? OIDServiceDiscovery(dictionary: dictResponse) else {
                     return reject(OktaError.ParseFailure)
                 }
+
+                // Cache the well-known endpoint response
+                OktaAuth.wellKnown = dictResponse
                 return resolve(OIDServiceConfiguration(discoveryDocument: oidcConfig))
             }
             .catch { error in

--- a/Okta/OktaError.swift
+++ b/Okta/OktaError.swift
@@ -14,6 +14,7 @@ public enum OktaError: Error {
     case APIError(String)
     case ErrorFetchingFreshTokens(String)
     case MissingConfigurationValues
+    case NoBearerToken
     case NoClientSecret(String)
     case NoDiscoveryEndpoint
     case NoIntrospectionEndpoint
@@ -35,6 +36,8 @@ extension OktaError: LocalizedError {
         case .MissingConfigurationValues:
             return NSLocalizedString("Could not parse 'issuer', 'clientId', and/or 'redirectUri' plist values. " +
                 "See https://github.com/okta/okta-sdk-appauth-ios/#configuration for more information.", comment: "")
+        case .NoBearerToken:
+            return NSLocalizedString("Missing Bearer token. You must authenticate first.", comment: "")
         case .NoClientSecret(plist: let plist):
             return NSLocalizedString(
                 "ClientSecret not included in PList configuration file: " +

--- a/Okta/OktaIntrospection.swift
+++ b/Okta/OktaIntrospection.swift
@@ -16,8 +16,8 @@ public struct Introspect {
     init() {}
 
     public func validate(_ token: String) -> Promise<Bool> {
+        // Validate token
         return Promise<Bool>(in: .background, { resolve, reject, _ in
-            // Validate token
             if let introspectionEndpoint = self.getIntrospectionEndpoint() {
                 // Build introspect request
                 let headers = [
@@ -44,8 +44,8 @@ public struct Introspect {
 
     func getIntrospectionEndpoint() -> URL? {
         // Get the introspection endpoint from the discovery URL, or build it
-        if let discoveryEndpoint = OktaAuth.tokens?.authState?.lastAuthorizationResponse.request.configuration.discoveryDocument?.discoveryDictionary["introspection_endpoint"] {
-            return URL(string: discoveryEndpoint as! String)
+        if let introspectionEndpoint = OktaAuth.wellKnown?["introspection_endpoint"] {
+            return URL(string: introspectionEndpoint as! String)
         }
 
         let issuer = OktaAuth.configuration?["issuer"] as! String

--- a/Okta/OktaUserInfo.swift
+++ b/Okta/OktaUserInfo.swift
@@ -12,19 +12,18 @@
 
 public struct UserInfo {
 
-    var token: String?
-
     init(token: String?, callback: @escaping ([String: Any]?, OktaError?) -> Void) {
-        self.token = token
-
         // Revoke the token
         if let userInfoEndpoint = getUserInfoEndpoint() {
-            // Build introspect request
+            guard let token = token else {
+                callback(nil, .NoBearerToken)
+                return
+            }
 
             let headers = [
                 "Accept": "application/json",
                 "Content-Type": "application/x-www-form-urlencoded",
-                "Authorization": "Bearer \(self.token!)"
+                "Authorization": "Bearer \(token)"
             ]
 
             OktaApi.post(userInfoEndpoint, headers: headers, postData: nil)
@@ -40,8 +39,8 @@ public struct UserInfo {
     func getUserInfoEndpoint() -> URL? {
         // Get the introspection endpoint from the discovery URL, or build it
 
-        if let discoveryEndpoint = OktaAuth.tokens?.authState?.lastAuthorizationResponse.request.configuration.discoveryDocument?.userinfoEndpoint {
-            return discoveryEndpoint
+        if let userInfoEndpoint = OktaAuth.wellKnown?["userinfo_endpoint"] {
+            return URL(string: userInfoEndpoint as! String)
         }
 
         let issuer = OktaAuth.configuration?["issuer"] as! String


### PR DESCRIPTION
- Caches the well-known endpoint response data for easy retrieval
- Adds tests to validate `accessToken` is provided to certain methods