### PR TITLE
Adds helper method for determining + resuming the authState

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: objective-c
-osx_image: xcode9.1
-
+osx_image: xcode9.2
 before_install:
-  - rvm install ruby-2.2.0
+  - rvm install ruby-2.3.1
   - gem install cocoapods
+  - gem install xcpretty
 script:
   - bash ./scripts/build-and-test.sh

--- a/Example/Okta.xcodeproj/project.pbxproj
+++ b/Example/Okta.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		7169AE1E1EF5F27200313EB8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		7173E8391F97F10D008BC82A /* Okta-PasswordFlow.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7173E8381F97F10D008BC82A /* Okta-PasswordFlow.plist */; };
 		71A92AF5202A7C4D0072EC32 /* UITestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A92AF3202A7C160072EC32 /* UITestUtils.swift */; };
+		71ED66192058BF8E00B5D800 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71ED66182058BF8E00B5D800 /* TestUtils.swift */; };
+		71ED661A2058C24B00B5D800 /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71ED66182058BF8E00B5D800 /* TestUtils.swift */; };
 		71F76E51BDB207F788887141 /* Pods_Okta_UITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4DF4896AAAB9BD5CAE67A8F /* Pods_Okta_UITests.framework */; };
 		E5E32C428E4371BB3E148847 /* Pods_Okta_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29991E729AD593DD12330109 /* Pods_Okta_Tests.framework */; };
 /* End PBXBuildFile section */
@@ -66,8 +68,9 @@
 		7137EDF91EFB281A0082C30F /* AppAuth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppAuth.framework; path = "../../Library/Developer/Xcode/DerivedData/Okta-auwqmzndabniaoghxgdrvwhlmgvr/Build/Products/Debug-iphonesimulator/AppAuth/AppAuth.framework"; sourceTree = "<group>"; };
 		7169AE1A1EF5EB8B00313EB8 /* Okta.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Okta.plist; sourceTree = "<group>"; };
 		7173E8381F97F10D008BC82A /* Okta-PasswordFlow.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Okta-PasswordFlow.plist"; sourceTree = "<group>"; };
-		71A92AF3202A7C160072EC32 /* UITestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestUtils.swift; sourceTree = "<group>"; };
 		71A92AF2202A6AD20072EC32 /* Vinculum.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Vinculum.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		71A92AF3202A7C160072EC32 /* UITestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestUtils.swift; sourceTree = "<group>"; };
+		71ED66182058BF8E00B5D800 /* TestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 		A40CCA2C6BE208FDEDEA0B7A /* Pods-Okta_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_Tests/Pods-Okta_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		A4D59B5275951E9231367D12 /* Pods-Okta_UITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_UITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_UITests/Pods-Okta_UITests.debug.xcconfig"; sourceTree = "<group>"; };
 		A4DF4896AAAB9BD5CAE67A8F /* Pods_Okta_UITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Okta_UITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -162,6 +165,7 @@
 			children = (
 				607FACEB1AFB9204008FA782 /* Tests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				71ED66182058BF8E00B5D800 /* TestUtils.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -559,6 +563,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
+				71ED66192058BF8E00B5D800 /* TestUtils.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -567,6 +572,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71ED661A2058C24B00B5D800 /* TestUtils.swift in Sources */,
 				7169AE1E1EF5F27200313EB8 /* AppDelegate.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* Tests.swift in Sources */,
 			);

--- a/Example/Okta.xcodeproj/xcshareddata/xcschemes/Okta-Example.xcscheme
+++ b/Example/Okta.xcodeproj/xcshareddata/xcschemes/Okta-Example.xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disableMainThreadChecker = "YES"
       language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>

--- a/Example/Okta.xcodeproj/xcshareddata/xcschemes/Okta-Example.xcscheme
+++ b/Example/Okta.xcodeproj/xcshareddata/xcschemes/Okta-Example.xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -79,6 +80,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -95,6 +97,18 @@
             ReferencedContainer = "container:Okta.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "USERNAME"
+            value = "$(USERNAME)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "PASSWORD"
+            value = "$(PASSWORD)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Example/Okta/Okta.plist
+++ b/Example/Okta/Okta.plist
@@ -9,8 +9,8 @@
 	<key>clientSecret</key>
 	<string></string>
 	<key>clientId</key>
-	<string>{clientId}</string>
+	<string>0oae1enia6od2nlz00h7</string>
 	<key>issuer</key>
-	<string>https://{yourOktaDomain}.com/oauth2/default</string>
+	<string>https://demo-org.oktapreview.com/oauth2/default</string>
 </dict>
 </plist>

--- a/Example/Okta/ViewController.swift
+++ b/Example/Okta/ViewController.swift
@@ -13,10 +13,17 @@ class ViewController: UIViewController {
 
     @IBOutlet weak var tokenView: UITextView!
 
-    override func viewDidLoad() { super.viewDidLoad() }
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if OktaAuth.isAuthenticated() {
+            // If there is a valid accessToken
+            // build the token view.
+            self.buildTokenTextView()
+        }
+    }
 
     @IBAction func loginButton(_ sender: Any) {
-        if tokens == nil { self.loginCodeFlow() }
+        self.loginCodeFlow()
     }
 
     @IBAction func clearTokens(_ sender: Any) {
@@ -56,11 +63,7 @@ class ViewController: UIViewController {
 
     func loginCodeFlow() {
         OktaAuth.login().start(self)
-        .then { authResponse in
-            tokens?.set(value: authResponse.accessToken!, forKey: "accessToken")
-            tokens?.set(value: authResponse.idToken!, forKey: "idToken")
-            self.buildTokenTextView()
-        }
+        .then { _ in self.buildTokenTextView() }
         .catch { error in print(error) }
     }
 
@@ -69,23 +72,22 @@ class ViewController: UIViewController {
     }
 
     func buildTokenTextView() {
-        if tokens == nil {
+        guard let currentTokens = tokens else {
             tokenView.text = ""
             return
         }
 
         var tokenString = ""
-
-        if let accessToken = tokens?.accessToken {
+        if let accessToken = currentTokens.accessToken {
             tokenString += ("\nAccess Token: \(accessToken)\n")
         }
 
-        if let idToken = tokens?.idToken {
-            tokenString += "\nidToken Token: \(idToken)\n"
+        if let idToken = currentTokens.idToken {
+            tokenString += "\nID Token: \(idToken)\n"
         }
 
-        if let refreshToken = tokens?.refreshToken {
-            tokenString += "\nrefresh Token: \(refreshToken)\n"
+        if let refreshToken = currentTokens.refreshToken {
+            tokenString += "\nRefresh Token: \(refreshToken)\n"
         }
 
         self.updateUI(updateText: tokenString)

--- a/Example/Okta_UITests/Okta_UITests.swift
+++ b/Example/Okta_UITests/Okta_UITests.swift
@@ -43,14 +43,6 @@ class OktaUITests: XCTestCase {
 
         app.buttons["Login"].tap()
 
-        // Wait for browser to load
-        // This sleep bypasses the need to "click" the consent for Safari
-        sleep(2)
-        
-        // Known bug with iOS 11 and system alerts (need to tap twice)
-        app.tap()
-        app.tap()
-
         // Login
         testUtils.login(username: username, password: password)
 

--- a/Example/Okta_UITests/Okta_UITests.swift
+++ b/Example/Okta_UITests/Okta_UITests.swift
@@ -14,15 +14,16 @@ import XCTest
 import OktaAuth
 
 class OktaUITests: XCTestCase {
-    var username = ""
-    var password = ""
+    // Update these values along with your Plist config
+    var username = "{username}"
+    var password = "{password}"
+
+    var testUtils: UITestUtils?
+    let app = XCUIApplication()
 
     override func setUp() {
         super.setUp()
-
-        // Update these values along with your Plist config
-        username = "{username}"
-        password = "{password}"
+        testUtils = UITestUtils(app)
 
         continueAfterFailure = false
         XCUIApplication().launch()
@@ -32,9 +33,13 @@ class OktaUITests: XCTestCase {
         super.tearDown()
     }
 
-    func testAuthorizationCodeFlow() {
-        let app = XCUIApplication()
-        let testUtils = UITestUtils(app)
+    func loginAndWait() {
+        guard let testUtils = testUtils else { return }
+
+        // Check to see if there are tokens displayed (indicating an authenticated state)
+        if let tokens = testUtils.getTextViewValue(label: "tokenView"), tokens.contains("Access Token") {
+            return
+        }
 
         app.buttons["Login"].tap()
 
@@ -45,42 +50,51 @@ class OktaUITests: XCTestCase {
         // Login
         testUtils.login(username: username, password: password)
 
-        // Wait for app to redirect back (Granting 3 second delay)
-        if !testUtils.waitForElement(app.textViews["tokenView"], timeout: 3) {
+        // Wait for app to redirect back (Granting 5 second delay)
+        if !testUtils.waitForElement(app.textViews["tokenView"], timeout: 5) {
             XCTFail("Unable to redirect back from browser")
         }
+    }
 
-        let tokenValues = testUtils.getTextViewValue(label: "tokenView")
+    func testAuthCodeFlow() {
+        loginAndWait()
+
+        let tokenValues = testUtils?.getTextViewValue(label: "tokenView")
         XCTAssertNotNil(tokenValues)
+    }
+
+    func testAuthCodeFlowAndUserInfo(){
+        loginAndWait()
 
         // Get User info
         app.buttons["GetUser"].tap()
 
-        let userInfoValue = testUtils.getTextViewValue(label: "tokenView")
+        let userInfoValue = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 2)
         XCTAssertTrue(userInfoValue!.contains(username))
+    }
+
+    func testAuthCodeFlowIntrospectAndRevoke() {
+        loginAndWait()
 
         // Introspect Valid Token
         app.buttons["Introspect"].tap()
 
-        let valid = testUtils.getTextViewValue(label: "tokenView")
+        let valid = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 2)
         XCTAssertTrue(valid!.contains("true"))
 
         // Revoke Token
         app.buttons["Revoke"].tap()
 
-        let revoked = testUtils.getTextViewValue(label: "tokenView")
+        let revoked = testUtils?.getTextViewValue(label: "tokenView")
         XCTAssertTrue(revoked!.contains("AccessToken was revoked"))
 
         // Introspect invalid Token
         app.buttons["Introspect"].tap()
 
-        let isNotValid = testUtils.getTextViewValue(label: "tokenView")
+        let isNotValid = testUtils?.getTextViewValue(label: "tokenView")
         XCTAssertTrue(isNotValid!.contains("false"))
 
-        // Clear Tokens
+        // Clear all tokens
         app.buttons["Clear"].tap()
-
-        let val = testUtils.getTextViewValue(label: "tokenView")
-        XCTAssertEqual(val!, "")
     }
 }

--- a/Example/Okta_UITests/Okta_UITests.swift
+++ b/Example/Okta_UITests/Okta_UITests.swift
@@ -15,8 +15,8 @@ import OktaAuth
 
 class OktaUITests: XCTestCase {
     // Update these values along with your Plist config
-    var username = "{username}"
-    var password = "{password}"
+    var username = ProcessInfo.processInfo.environment["USERNAME"]!
+    var password = ProcessInfo.processInfo.environment["PASSWORD"]!
 
     var testUtils: UITestUtils?
     let app = XCUIApplication()
@@ -25,7 +25,7 @@ class OktaUITests: XCTestCase {
         super.setUp()
         testUtils = UITestUtils(app)
 
-        continueAfterFailure = false
+        continueAfterFailure = true
         XCUIApplication().launch()
     }
 
@@ -46,6 +46,10 @@ class OktaUITests: XCTestCase {
         // Wait for browser to load
         // This sleep bypasses the need to "click" the consent for Safari
         sleep(2)
+        
+        // Known bug with iOS 11 and system alerts (need to tap twice)
+        app.tap()
+        app.tap()
 
         // Login
         testUtils.login(username: username, password: password)
@@ -59,7 +63,7 @@ class OktaUITests: XCTestCase {
     func testAuthCodeFlow() {
         loginAndWait()
 
-        let tokenValues = testUtils?.getTextViewValue(label: "tokenView")
+        let tokenValues = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertNotNil(tokenValues)
     }
 
@@ -69,7 +73,7 @@ class OktaUITests: XCTestCase {
         // Get User info
         app.buttons["GetUser"].tap()
 
-        let userInfoValue = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 2)
+        let userInfoValue = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertTrue(userInfoValue!.contains(username))
     }
 
@@ -79,19 +83,23 @@ class OktaUITests: XCTestCase {
         // Introspect Valid Token
         app.buttons["Introspect"].tap()
 
-        let valid = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 2)
+        let valid = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertTrue(valid!.contains("true"))
+    }
+
+    func testAuthCodeFlowRevokeAndIntrospect() {
+        loginAndWait()
 
         // Revoke Token
         app.buttons["Revoke"].tap()
 
-        let revoked = testUtils?.getTextViewValue(label: "tokenView")
+        let revoked = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertTrue(revoked!.contains("AccessToken was revoked"))
 
         // Introspect invalid Token
         app.buttons["Introspect"].tap()
 
-        let isNotValid = testUtils?.getTextViewValue(label: "tokenView")
+        let isNotValid = testUtils?.getTextViewValueWithDelay(label: "tokenView", delay: 5)
         XCTAssertTrue(isNotValid!.contains("false"))
 
         // Clear all tokens

--- a/Example/Okta_UITests/UITestUtils.swift
+++ b/Example/Okta_UITests/UITestUtils.swift
@@ -19,6 +19,13 @@ public struct UITestUtils {
     }
 
     func login(username: String, password: String) {
+        // Wait for browser to load
+        // This sleep bypasses the need to "click" the consent for Safari
+        sleep(5)
+
+        // Known bug with iOS 11 and system alerts
+        testApp.tap()
+
         // Login via username and password inside of the Safari WebView
         let webViewsQuery = testApp.webViews
         let usernameField = webViewsQuery.textFields["Username"]

--- a/Example/Okta_UITests/UITestUtils.swift
+++ b/Example/Okta_UITests/UITestUtils.swift
@@ -24,6 +24,10 @@ public struct UITestUtils {
         let usernameField = webViewsQuery.textFields["Username"]
         let passwordField = webViewsQuery.secureTextFields["Password"]
 
+        if !waitForElement(usernameField, timeout: 10) && waitForElement(passwordField, timeout: 10) {
+            return
+        }
+
         usernameField.tap()
         usernameField.typeText(username)
         passwordField.tap()

--- a/Example/Okta_UITests/UITestUtils.swift
+++ b/Example/Okta_UITests/UITestUtils.swift
@@ -31,7 +31,7 @@ public struct UITestUtils {
         let usernameField = webViewsQuery.textFields["Username"]
         let passwordField = webViewsQuery.secureTextFields["Password"]
 
-        if !waitForElement(usernameField, timeout: 10) && waitForElement(passwordField, timeout: 10) {
+        if !waitForElement(usernameField, timeout: 5) && !waitForElement(passwordField, timeout: 5) {
             return
         }
 

--- a/Example/Okta_UITests/UITestUtils.swift
+++ b/Example/Okta_UITests/UITestUtils.swift
@@ -39,6 +39,12 @@ public struct UITestUtils {
         return nil
     }
 
+    func getTextViewValueWithDelay(label: String, delay: UInt32) -> String? {
+        // Returns the value of a textView after a given delay
+        sleep(delay)
+        return getTextViewValue(label: label)
+    }
+
     func waitForElement(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
         // Generic wait for element to apepar function w/ timeout
         let pred = NSPredicate(format: "exists == true")

--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -1,0 +1,51 @@
+//
+//  TestUtils.swift
+//  Okta_Example
+//
+//  Created by Jordan Melberg on 3/13/18.
+//  Copyright © 2018 Okta. All rights reserved.
+//
+
+import AppAuth
+import OktaAuth
+import Vinculum
+
+struct TestUtils {
+    static let tokenManager = TestUtils.setupMockTokenManager(issuer: "https://demo-org.oktapreview.com/oauth2/default")
+
+    static func setupMockTokenManager(issuer: String) -> OktaTokenManager {
+        // Creates a mock Okta Token Manager object
+        let fooURL = URL(string: issuer)!
+        let mockServiceConfig = OIDServiceConfiguration(authorizationEndpoint: fooURL, tokenEndpoint: fooURL)
+        let mockTokenRequest = OIDTokenRequest(
+                   configuration: mockServiceConfig,
+                       grantType: OIDGrantTypeRefreshToken,
+               authorizationCode: nil,
+                     redirectURL: fooURL,
+                        clientID: "nil",
+                    clientSecret: nil,
+                           scope: nil,
+                    refreshToken: nil,
+                    codeVerifier: nil,
+            additionalParameters: nil
+        )
+        let mockTokenResponse = OIDTokenResponse(request: mockTokenRequest, parameters: [:])
+        let tempAuthState = OIDAuthState(authorizationResponse: nil, tokenResponse: mockTokenResponse, registrationResponse: nil)
+
+        return OktaTokenManager(authState: tempAuthState, config: [:])
+    }
+
+    static func getPreviousState() -> OktaTokenManager? {
+        // Return the previous archived state
+        guard let encodedAuthStateItem = try? Vinculum.get("OktaAuthStateTokenManager"),
+            let encodedAuthState = encodedAuthStateItem else {
+                return nil
+        }
+        guard let previousState = NSKeyedUnarchiver
+            .unarchiveObject(with: encodedAuthState.value) as? OktaTokenManager else {
+                return nil
+        }
+
+        return previousState
+    }
+}

--- a/Okta/OktaAppAuth.swift
+++ b/Okta/OktaAppAuth.swift
@@ -11,6 +11,7 @@
  */
 
 import AppAuth
+import Vinculum
 
 // Current version of the SDK
 let VERSION = "0.3.0"
@@ -35,6 +36,24 @@ public func login(_ username: String, password: String) -> Login {
 public func login() -> Login {
     // Authenticate via authorization code flow
     return Login()
+}
+
+public func isAuthenticated() -> Bool {
+    // Restore state
+    guard let encodedAuthStateItem = try? Vinculum.get("OktaAuthStateTokenManager"),
+        let encodedAuthState = encodedAuthStateItem else {
+        return false
+    }
+
+    guard let previousState = NSKeyedUnarchiver
+        .unarchiveObject(with: encodedAuthState.value) as? OktaTokenManager else { return false }
+
+    tokens = previousState
+
+    if tokens?.accessToken != nil {
+        return true
+    }
+    return false
 }
 
 public func introspect() -> Introspect {

--- a/Okta/OktaRefresh.swift
+++ b/Okta/OktaRefresh.swift
@@ -20,8 +20,8 @@ internal struct Refresh {
                 return reject(OktaError.NoRefreshToken)
             }
 
-            tokens?.authState?.setNeedsTokenRefresh()
-            tokens?.authState?.performAction(freshTokens: { accessToken, idToken, error in
+            tokens?.authState.setNeedsTokenRefresh()
+            tokens?.authState.performAction(freshTokens: { accessToken, idToken, error in
                 if error != nil {
                     return reject(OktaError.ErrorFetchingFreshTokens(error!.localizedDescription))
                 }

--- a/Okta/OktaTokenManager.swift
+++ b/Okta/OktaTokenManager.swift
@@ -15,26 +15,30 @@ import Vinculum
 
 open class OktaTokenManager: NSObject, NSCoding {
 
-    private var _idToken: String? = nil
+    internal var _idToken: String? = nil
 
     open var authState: OIDAuthState
     open var config: [String: String]
     open var accessibility: CFString
 
-    open var idToken: String? {
-        get { return self._idToken }
-    }
-
-    open var refreshToken: String? {
+    open var accessToken: String? {
+        // Return the known accessToken
         get {
-            guard let token = self.authState.refreshToken else { return nil }
+            guard let token = self.authState.lastTokenResponse?.accessToken else { return nil }
             return token
         }
     }
 
-    open var accessToken: String? {
+    open var idToken: String? {
+        // Return the known idToken via the internal _idToken var
+        // since it gets lost on refresh
+        get { return self._idToken }
+    }
+
+    open var refreshToken: String? {
+        // Return the known refreshToken
         get {
-            guard let token = self.authState.lastTokenResponse?.accessToken else { return nil }
+            guard let token = self.authState.refreshToken else { return nil }
             return token
         }
     }

--- a/Okta/OktaUserInfo.swift
+++ b/Okta/OktaUserInfo.swift
@@ -18,7 +18,7 @@ internal struct UserInfo {
             callback(nil, .NoUserInfoEndpoint)
             return
         }
-
+        
         guard let token = token else {
             callback(nil, .NoBearerToken)
             return

--- a/Okta/OktaUserInfo.swift
+++ b/Okta/OktaUserInfo.swift
@@ -18,7 +18,7 @@ internal struct UserInfo {
             callback(nil, .NoUserInfoEndpoint)
             return
         }
-        
+
         guard let token = token else {
             callback(nil, .NoBearerToken)
             return

--- a/README.md
+++ b/README.md
@@ -98,120 +98,108 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpe
 }
 ```
 
-
 Then, you can start the authorization flow by simply calling `login`:
 
 ```swift
-OktaAuth
-    .login()
-    .start(view: self) { response, error in
-        if error != nil {
-            print("Error: \(error!)")
-        }
-
-        // Success
-        if let authResponse = response {
-            // authResponse.accessToken
-            // authResponse.idToken
-        }
-    }
+OktaAuth.login().start(view: self)
+.then { tokenManager in
+    // tokenManager.accessToken
+    // tokenManager.idToken
+    // tokenManager.refreshToken
+}
+.catch { error in
+    // Error
+}
 ```
 
 To login using `username` and `password`:
 
 ```swift
-OktaAuth
-    .login(username: "user@example.com", password: "password")
-    .start(view: self) { response, error in
-        if error != nil {
-            print("Error: \(error!)")
-        }
+OktaAuth.login(username: "user@example.com", password: "password").start(view: self)
+.then { tokenManager in
+    // tokenManager.accessToken
+    // tokenManager.idToken
+    // tokenManager.refreshToken
+}
+.catch { error in
+    // Error
+}
+```
 
-        // Success
-        if let authResponse = response {
-            // authResponse.accessToken
-            // authResponse.idToken
-        }
-    }
+### Handle the Authentication State
+Returns `true` if there is a valid access token stored in the TokenManager. This is the best way to determine if a user has successfully authenticated into your app.
+
+```swift
+if !OktaAuth.isAuthenticated() {
+    // Prompt for login
+}
 ```
 
 ### Get UserInfo
 Calls the OIDC userInfo endpoint to return user information.
 
 ```swift
-OktaAuth
-    .userinfo() { response, error in
-        if error != nil {
-            print("Error: \(error!)")
-        }
-
-        if let userinfo = response {
-            userinfo.forEach { print("\($0): \($1)") }
-        }
+OktaAuth.userinfo() { response, error in
+    if error != nil {
+        print("Error: \(error!)")
     }
+
+    if let userinfo = response {
+        userinfo.forEach { print("\($0): \($1)") }
+    }
+}
 ```
 
 ### Introspect a Token
 Calls the introspection endpoint to inspect the validity of the specified token.
 
 ```swift
-OktaAuth
-    .introspect()
-    .validate(token: token) { response, error in
-        if error != nil {
-            print("Error: \(error!)")
-        }
-
-        if let isActive = response {
-            print("Is token valid? \(isActive)")
-        }
-    }
+OktaAuth.introspect().validate(token: token)
+.then { isActive in
+    print("Is token valid? \(isActive)")
+}
+.catch { error in
+    // Error
+}
 ```
 
 ### Revoke a Token
 Calls the revocation endpoint to revoke the specified token.
 
 ```swift
-OktaAuth
-    .revoke(token: token) { response, error in
-        if error != nil {
-            print("Error: \(error!)")
-        }
-        if let _ = response {
-            print("Token was revoked")
-        }
+OktaAuth.revoke(token: token) { response, error in
+    if error != nil {
+        print("Error: \(error!)")
     }
-```
-
-### Refresh a Token
-Refreshes the `accessToken` if the `refreshToken` is provided.
-
-```swift
-OktaAuth.refresh()
+    if let _ = response {
+        print("Token was revoked")
+    }
+}
 ```
 
 ### Token Management
-Tokens are securely stored in the Keychain. They can be easily be set and retrieved with the helper methods `set` and `get`.
+Tokens are securely stored in the Keychain and can be retrieved from the TokenManager.
 
 ```swift
-OktaAuth
-    .login()
-    .start(self) { response, error in
-        if error != nil {
-            print(error!)
-        }
-
-        if let authResponse = response {
-            // Store tokens in keychain
-            OktaAuth.tokens?.set(value: authResponse.accessToken!, forKey: "accessToken")
-            OktaAuth.tokens?.set(value: authResponse.idToken!, forKey: "idToken")
-        }
-    }
-
-// OktaAuth.tokens?.get(forKey: "accessToken")
-// OktaAuth.tokens?.get(forKey: "idToken")
+OktaAuth.tokens?.accessToken
+OktaAuth.tokens?.idToken
+OktaAuth.tokens?.refreshToken
 ```
 
-## License
+## Development
 
+### Running Tests
+To perform an end-to-end test, update the `Okta.plist` file to match your configuration as specified in the [prerequisites](#prerequisites). Next, export the following environment variables:
+
+```bash
+export USERNAME={username}
+export PASSWORD={password}
+
+# Run E2E end Unit tests
+bash ./scripts/build-and-test.sh
+```
+
+**Note:** *You may need to update the emulator device to match your Xcode version*
+
+## License
 Okta is available under the Apache 2.0 license. See the LICENSE file for more info.

--- a/scripts/build-and-test.sh
+++ b/scripts/build-and-test.sh
@@ -1,33 +1,25 @@
 #!/bin/bash
+source "${0%/*}/helpers.sh"
 
 set -e
 
 # Go to correct path for install
 cd Example
 
-
-function pod_install() {
-    echo "==== Installing pods ===="
-    pod install --repo-update
-}
-
-if ! pod_install; then
+if ! pod_dependencies; then
     exit 1
 fi
 
-function build_and_test_workspace() {
-    echo "*******************"
-    echo "Building Workspace"
-    echo "*******************"
-    xcodebuild test \
-    -workspace Okta.xcworkspace/ \
-    -scheme Okta-Example \
-    -destination 'platform=iOS Simulator,OS=11.1,name=iPhone 8' \
-    -only-testing:Okta_Tests
-}
+echo "- Starting tests..."
 
-if ! build_and_test_workspace; then
+if ! build_and_run_ui_tests "$USERNAME" "$PASSWORD"; then
     exit 1
+else
+  echo -e "\xE2\x9C\x94 Passed UI tests"
 fi
 
-echo "All tests passed"
+if ! build_and_run_unit_tests; then
+    exit 1
+else
+  echo -e "\xE2\x9C\x94 Passed Unit tests"
+fi

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Set workspace
+WORKSPACE="Okta.xcworkspace/"
+
+# Set scheme
+SCHEME="Okta-Example"
+
+# Set test devices
+IPHONE_X_DESTINATION="OS=11.2,name=iPhone X"
+
+pod_dependencies () {
+    echo "- Installing dependencies"
+    echo "└─  Installing pods"
+    pod install --repo-update --silent
+}
+
+build_and_run_unit_tests () {
+    remove_simulator_data
+
+    echo "└─  Starting Unit Tests"
+
+    set -o pipefail && xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
+    -destination "$IPHONE_X_DESTINATION" \
+    -only-testing:Okta_Tests test | xcpretty;
+}
+
+build_and_run_ui_tests () {
+    remove_simulator_data
+    
+    echo "└─  Starting UI Tests"
+    
+    set -o pipefail && xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
+    -destination "$IPHONE_X_DESTINATION" \
+    -only-testing:Okta_UITests \
+    USERNAME="$1" PASSWORD="$2" test | xcpretty;
+}
+
+remove_simulator_data () {
+    echo "└─  Removing Simulator Data"
+    xcrun simctl erase all
+}


### PR DESCRIPTION
Allows the ability to easily manage user state on app setup. The method `isAuthenticated()` checks for an `accessToken` stored in the Keychain. If available, it will attempt to deserialize the last `authState` response to resume the user's state.

```swift
// ViewController.swift
override func viewDidLoad() {
    ...
    if !OktaAuth.isAuthenticated() {
        // Start the login flow
    }
}
```

Resolves: [OKTA-153412](https://oktainc.atlassian.net/browse/OKTA-153412) and #21 