### PR TITLE
:seedling: Adds idToken validation

### DIFF
--- a/Example/Okta.xcodeproj/project.pbxproj
+++ b/Example/Okta.xcodeproj/project.pbxproj
@@ -75,7 +75,7 @@
 		A4D59B5275951E9231367D12 /* Pods-Okta_UITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_UITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_UITests/Pods-Okta_UITests.debug.xcconfig"; sourceTree = "<group>"; };
 		A4DF4896AAAB9BD5CAE67A8F /* Pods_Okta_UITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Okta_UITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5E013FAC6C3834F6BDD80C6 /* Pods-Okta_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_Example/Pods-Okta_Example.release.xcconfig"; sourceTree = "<group>"; };
-		B54721B8796F7E4B1803D294 /* OktaAuth.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = OktaAuth.podspec; path = ../OktaAuth.podspec; sourceTree = "<group>"; };
+		B54721B8796F7E4B1803D294 /* OktaAuth.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = OktaAuth.podspec; path = ../OktaAuth.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		BE6FD1DAFDE74ECC28A6A10E /* Pods-Okta_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_Example/Pods-Okta_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		C6B761A3CC831DEA678C8167 /* Pods-Okta_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_Tests/Pods-Okta_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		D6A9C9F6477128D034833C7D /* Pods-Okta_UITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Okta_UITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Okta_UITests/Pods-Okta_UITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -399,6 +399,7 @@
 				"${BUILT_PRODUCTS_DIR}/AppAuth/AppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
 				"${BUILT_PRODUCTS_DIR}/OktaAuth/OktaAuth.framework",
+				"${BUILT_PRODUCTS_DIR}/OktaJWT/OktaJWT.framework",
 				"${BUILT_PRODUCTS_DIR}/Vinculum/Vinculum.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -406,6 +407,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OktaAuth.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OktaJWT.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Vinculum.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -423,6 +425,7 @@
 				"${BUILT_PRODUCTS_DIR}/AppAuth/AppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
 				"${BUILT_PRODUCTS_DIR}/OktaAuth/OktaAuth.framework",
+				"${BUILT_PRODUCTS_DIR}/OktaJWT/OktaJWT.framework",
 				"${BUILT_PRODUCTS_DIR}/Vinculum/Vinculum.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -430,6 +433,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OktaAuth.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OktaJWT.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Vinculum.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -447,6 +451,7 @@
 				"${BUILT_PRODUCTS_DIR}/AppAuth/AppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/HydraAsync/Hydra.framework",
 				"${BUILT_PRODUCTS_DIR}/OktaAuth/OktaAuth.framework",
+				"${BUILT_PRODUCTS_DIR}/OktaJWT/OktaJWT.framework",
 				"${BUILT_PRODUCTS_DIR}/Vinculum/Vinculum.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -454,6 +459,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Hydra.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OktaAuth.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OktaJWT.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Vinculum.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,6 @@ use_frameworks!
 
 def shared_pods
     pod 'OktaAuth', :path => '../'
-    pod 'Vinculum'
 end
 
 

--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -9,11 +9,29 @@
 import AppAuth
 import OktaAuth
 import Vinculum
+import Hydra
 
 struct TestUtils {
-    static let tokenManager = TestUtils.setupMockTokenManager(issuer: "https://demo-org.oktapreview.com/oauth2/default")
+    static let mockIssuer = "https://demo-org.oktapreview.com/oauth2/default"
+    static let mockClientId = "0oae1enia6od2nlz00h7"
+    static let mockScopes = "openid email"
 
-    static func setupMockTokenManager(issuer: String) -> OktaTokenManager {
+    static let mockAccessToken = "abc.123.xyz"
+    static let mockIdToken = "eyJraWQiOiIwWG9xWm1abTVuQlF0UnhUd3E1VDI5czBUenF0RGowenNyOGxGSHA5OHZnIiwiYWxnIjoiUlMyNTYifQ." +
+        "eyJzdWIiOiIwMHVlMWdpMHB0WnBhNjdwVTBoNyIsIm5hbWUiOiJKb3JkYW4gTWVsYmVyZyIsInZlciI6MSwiaXNzIjoiaHR0cHM6Ly9kZW1vLW9yZy" +
+        "5va3RhcHJldmlldy5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiIwb2FlMWVuaWE2b2Qybmx6MDBoNyIsImlhdCI6MTUyMTIzMDMzNiwiZXhwIjox" +
+        "NTIxMjMzOTM2LCJqdGkiOiJJRC5Fc0g5MndqVU1fNTJOdHg1Mlc0QkFpNGVlRUlJak5WbFZYaVZxbkR5S2U4IiwiYW1yIjpbInB3ZCJdLCJpZHAiOi" +
+        "IwMG9lMWdpMG5mU3FBY0VaMjBoNyIsInByZWZlcnJlZF91c2VybmFtZSI6ImpvcmRhbi5tZWxiZXJnQG9rdGEuY29tIiwiYXV0aF90aW1lIjoxNTIx" +
+        "MjMwMzM1LCJhdF9oYXNoIjoiUmNRM2dHeXQ3bHJIckFwenF4RkxmQSJ9.GTrgb19Rb_hJhcKj1NvvMfhkX9_bbn5RNCefH285TEJL0lsmytC60GUiY-" +
+        "MQfI0DkjvBC7Yd2NS4hQyX3YlUn5vWcL6B_cQe-nSR3RD8pvnfmKh28mGrqtn0qfLxq9LmPskKZuXgjBY_hiFpRW-XzGWOgfYp-6t6oDN4LP92bnNNW" +
+        "qNelEI21kePdJQ3fItn3lwhBAFzJ3X35LOJr4-4XAqF0K-dOcpJ_EVyVMUtuQ4s3CD5xfrhYeRbz8d8As7Np7CCqTpWgS1L4AVMvMwdu6QaCo2bMYqH" +
+        "pu1WrZzuBHoQXuDkuYH6xKbKU2bopZGnA8PwrsIbr6PmmTaeH5ww0Q"
+    static let mockRefreshToken = "mockRefreshToken"
+
+    static let tokenManager = TestUtils.setupMockTokenManager(issuer: mockIssuer, options: nil)
+    static let tokenManagerNoValidation = TestUtils.setupMockTokenManager(issuer: mockIssuer, options: ["issuer": mockIssuer])
+
+    static func setupMockTokenManager(issuer: String, options: [String: Any]?) -> Promise<OktaTokenManager> {
         // Creates a mock Okta Token Manager object
         let fooURL = URL(string: issuer)!
         let mockServiceConfig = OIDServiceConfiguration(authorizationEndpoint: fooURL, tokenEndpoint: fooURL)
@@ -29,10 +47,36 @@ struct TestUtils {
                     codeVerifier: nil,
             additionalParameters: nil
         )
-        let mockTokenResponse = OIDTokenResponse(request: mockTokenRequest, parameters: [:])
+
+        let mockTokenResponse = OIDTokenResponse(
+            request: mockTokenRequest,
+            parameters: [
+                "access_token": mockAccessToken as NSCopying & NSObjectProtocol,
+                "expires_in": 300 as NSCopying & NSObjectProtocol,
+                "token_type": "Bearer" as NSCopying & NSObjectProtocol,
+                "id_token": mockIdToken as NSCopying & NSObjectProtocol,
+                "refresh_token": mockRefreshToken as NSCopying & NSObjectProtocol,
+                "scope": mockScopes as NSCopying & NSObjectProtocol
+            ]
+        )
+
         let tempAuthState = OIDAuthState(authorizationResponse: nil, tokenResponse: mockTokenResponse, registrationResponse: nil)
 
-        return OktaTokenManager(authState: tempAuthState, config: [:])
+        return Promise<OktaTokenManager>(in: .background, { resolve, reject, _ in
+            do {
+                let tm = try OktaTokenManager(
+                    authState: tempAuthState,
+                    config: [
+                        "issuer": mockIssuer,
+                        "clientId": mockClientId
+                    ],
+                    validationOptions: options
+                )
+                return resolve(tm)
+            } catch let error {
+                return reject(error)
+            }
+        })
     }
 
     static func getPreviousState() -> OktaTokenManager? {
@@ -45,7 +89,6 @@ struct TestUtils {
             .unarchiveObject(with: encodedAuthState.value) as? OktaTokenManager else {
                 return nil
         }
-
         return previousState
     }
 }

--- a/Okta/OktaAuth.swift
+++ b/Okta/OktaAuth.swift
@@ -42,12 +42,15 @@ public struct OktaAuthorization {
                     guard let authResponse = authorizationResponse else {
                         return reject(OktaError.APIError("Authorization Error: \(error!.localizedDescription)"))
                     }
+                    do {
+                        let tokenManager = try OktaTokenManager(authState: authResponse, config: config, validationOptions: nil)
 
-                    let tokenManager = OktaTokenManager(authState: authResponse, config: config)
-
-                    // Set the local cache and write to storage
-                    self.storeAuthState(tokenManager)
-                    return resolve(tokenManager)
+                        // Set the local cache and write to storage
+                        self.storeAuthState(tokenManager)
+                        return resolve(tokenManager)
+                    } catch let error {
+                        return reject(error)
+                    }
                 }
             }
             .catch { error in return reject(error) }
@@ -93,11 +96,15 @@ public struct OktaAuthorization {
                              registrationResponse: nil
                         )
 
-                        let tokenManager = OktaTokenManager(authState: authState, config: config)
+                        do {
+                            let tokenManager = try OktaTokenManager(authState: authState, config: config, validationOptions: nil)
 
-                        // Set the local cache and write to storage
-                        self.storeAuthState(tokenManager)
-                        return resolve(tokenManager)
+                            // Set the local cache and write to storage
+                            self.storeAuthState(tokenManager)
+                            return resolve(tokenManager)
+                        } catch let error {
+                            return reject(error)
+                        }
                     }
                 }
             }

--- a/Okta/OktaError.swift
+++ b/Okta/OktaError.swift
@@ -14,6 +14,7 @@ public enum OktaError: Error {
     case APIError(String)
     case ErrorFetchingFreshTokens(String)
     case JWTDecodeError
+    case JWTValidationError(String)
     case MissingConfigurationValues
     case NoBearerToken
     case NoClientSecret(String)
@@ -36,6 +37,8 @@ extension OktaError: LocalizedError {
             return NSLocalizedString("Error fetching fresh tokens: \(error)", comment: "")
         case .JWTDecodeError:
             return NSLocalizedString("Could not parse the given JWT string payload.", comment: "")
+        case .JWTValidationError(error: let error):
+            return NSLocalizedString("Could not validate the JWT: \(error)", comment: "")
         case .MissingConfigurationValues:
             return NSLocalizedString("Could not parse 'issuer', 'clientId', and/or 'redirectUri' plist values. " +
                 "See https://github.com/okta/okta-sdk-appauth-ios/#configuration for more information.", comment: "")

--- a/Okta/OktaIntrospection.swift
+++ b/Okta/OktaIntrospection.swift
@@ -10,6 +10,7 @@
  * See the License for the specific language governing permissions and limitations under the License.
  */
 import Hydra
+import OktaJWT
 
 public struct Introspect {
 
@@ -39,7 +40,7 @@ public struct Introspect {
             .catch { error in reject(OktaError.NoIntrospectionEndpoint) }
         })
     }
-    
+
     public func decode(_ token: String) -> Promise<[String: Any]?> {
         // Decodes the payload of a JWT
         return Promise<[String: Any]?>(in: .background, { resolve, reject, _ in
@@ -56,6 +57,18 @@ public struct Introspect {
             }
             return reject(OktaError.JWTDecodeError)
         })
+    }
+
+    public func validate(jwt: String, options: [String: Any]) throws -> Bool {
+        // Validates a JWT String based on a series of options
+        let validator = OktaJWTValidator(options)
+
+        do {
+            let isValid = try validator.isValid(jwt)
+            return isValid
+        } catch let error {
+            throw OktaError.JWTValidationError(error.localizedDescription)
+        }
     }
 
     func getIntrospectionEndpoint() -> URL? {

--- a/Okta/OktaUtils.swift
+++ b/Okta/OktaUtils.swift
@@ -77,6 +77,10 @@ open class Utils: NSObject {
         configCopy.removeValue(forKey: "clientId")
         configCopy.removeValue(forKey: "redirectUri")
         configCopy.removeValue(forKey: "scopes")
+
+        // Add nonce to additional params
+        configCopy["nonce"] = configCopy["nonce"] != nil ? configCopy["nonce"] : UUID().uuidString
+
         return configCopy
     }
 }

--- a/OktaAuth.podspec
+++ b/OktaAuth.podspec
@@ -16,4 +16,5 @@ Integrate your native app with Okta using the AppAuth library.
   s.dependency 'AppAuth', '~> 0.91.0'
   s.dependency 'Vinculum', '~> 0.2.0'
   s.dependency 'HydraAsync', '~> 1.0.1'
+  s.dependency 'OktaJWT', '~> 1.0.0'
 end


### PR DESCRIPTION
### Description
🌱 Before the token is placed into storage, the `idToken` is validated per [OIDC 3.1.3.7](http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation)
- Our implementation *does* make opinionated validation assumptions (clock-drift, nonce, etc)
- For testing purposes, we allow validation options to be passed into the `TokenManager` constructor. This will be bubbled up to the developer in a follow-up PR.


Resolves: OKTA-157796