### PR TITLE
:seedling: Check for expiration on tokens before return

### DIFF
--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -32,8 +32,10 @@ struct TestUtils {
 
     static let tokenManager = TestUtils.setupMockTokenManager(issuer: mockIssuer, options: nil)
     static let tokenManagerNoValidation = TestUtils.setupMockTokenManager(issuer: mockIssuer, options: ["issuer": mockIssuer])
+    static let tokenManagerNoValidationWithExpiration = TestUtils.setupMockTokenManager(issuer: mockIssuer, options: ["issuer": mockIssuer], expiresIn: 5)
 
-    static func setupMockTokenManager(issuer: String, options: [String: Any]?) -> Promise<OktaTokenManager> {
+
+    static func setupMockTokenManager(issuer: String, options: [String: Any]?, expiresIn: TimeInterval = 300) -> Promise<OktaTokenManager> {
         // Creates a mock Okta Token Manager object
         let fooURL = URL(string: issuer)!
         let mockServiceConfig = OIDServiceConfiguration(authorizationEndpoint: fooURL, tokenEndpoint: fooURL)
@@ -54,7 +56,7 @@ struct TestUtils {
             request: mockTokenRequest,
             parameters: [
                 "access_token": mockAccessToken as NSCopying & NSObjectProtocol,
-                "expires_in": 300 as NSCopying & NSObjectProtocol,
+                "expires_in": expiresIn as NSCopying & NSObjectProtocol,
                 "token_type": "Bearer" as NSCopying & NSObjectProtocol,
                 "id_token": mockIdToken as NSCopying & NSObjectProtocol,
                 "refresh_token": mockRefreshToken as NSCopying & NSObjectProtocol,

--- a/Okta/OktaAppAuth.swift
+++ b/Okta/OktaAppAuth.swift
@@ -11,6 +11,7 @@
  */
 
 import AppAuth
+import Hydra
 import Vinculum
 
 // Current version of the SDK
@@ -59,6 +60,11 @@ public func isAuthenticated() -> Bool {
 public func introspect() -> Introspect {
     // Check the validity of the tokens
     return Introspect()
+}
+
+public func refresh() -> Promise<String> {
+    // Refreshes the access token if a refresh token is present
+    return Refresh().refresh()
 }
 
 public func revoke(_ token: String?, callback: @escaping (Bool?, OktaError?) -> Void) {

--- a/README.md
+++ b/README.md
@@ -6,21 +6,26 @@
 [![Platform](https://img.shields.io/cocoapods/p/OktaAuth.svg?style=flat)](http://cocoapods.org/pods/OktaAuth)
 
 ## Overview
+
 This library is a **wrapper** around the [AppAuth-iOS](https://github.com/openid/AppAuth-iOS) SDK for communicating with OAuth 2.0 + OpenID Connect providers, and follows current best practice outlined in [RFC 8252 - OAuth 2.0 for Native Apps](https://tools.ietf.org/html/rfc8252).
 
 This library currently supports:
-  - [OAuth 2.0 Authorization Code Flow](https://tools.ietf.org/html/rfc6749#section-4.1) using the [PKCE extension](https://tools.ietf.org/html/rfc7636)
-  - [Resource Owner Password Grant](https://tools.ietf.org/html/rfc6749#section-1.3.3)
+
+- [OAuth 2.0 Authorization Code Flow](https://tools.ietf.org/html/rfc6749#section-4.1) using the [PKCE extension](https://tools.ietf.org/html/rfc7636)
+- [Resource Owner Password Grant](https://tools.ietf.org/html/rfc6749#section-1.3.3)
 
 ## Give it a Test Run
+
 To run the example project, run `pod try OktaAuth`.
 
 ## Prerequisites
+
 If you do not already have a **Developer Edition Account**, you can create one at [https://developer.okta.com/signup/](https://developer.okta.com/signup/).
 
 ### Add an OpenID Connect Client
-* Log into the Okta Developer Dashboard, click **Applications** then **Add Application**.
-* Choose **Native app** as the platform, then populate your new OpenID Connect application with values similar to:
+
+- Log into the Okta Developer Dashboard, click **Applications** then **Add Application**.
+- Choose **Native app** as the platform, then populate your new OpenID Connect application with values similar to:
 
 | Setting             | Value                                               |
 | ------------------- | --------------------------------------------------- |
@@ -42,6 +47,7 @@ These values will be used in your iOS application to setup the OpenID Connect fl
 > If using the [Resource Owner Password Grant](https://tools.ietf.org/html/rfc6749#section-1.3.3), make sure to select it in the **Allowed Grant Types** and select **Client authentication**.
 
 ## Installation
+
 Okta is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
@@ -50,6 +56,7 @@ pod "OktaAuth"
 ```
 
 ### Configuration
+
 Create an `Okta.plist` file in your application's bundle with the following fields:
 
 ```xml
@@ -72,11 +79,13 @@ Create an `Okta.plist` file in your application's bundle with the following fiel
 **Note**: *To receive a **refresh_token**, you must include the `offline_access` scope.*
 
 ### Update the Private-use URI Scheme
+
 In order to redirect back to your application from a web browser, you must specify a unique URI to your app. To do this, open `Info.plist` in your application bundle and set a **URL Scheme** to the scheme of the redirect URI.
 
 For example, if your **Redirect URI** is `com.okta.example:/callback`, the **URL Scheme** will be `com.okta.example`.
 
 ### Resource Owner Password
+
 If using the [Resource Owner Password Grant](https://tools.ietf.org/html/rfc6749#section-1.3.3), you must specify the `clientSecret` in `Okta.plist`:
 
 ```xml
@@ -87,6 +96,7 @@ If using the [Resource Owner Password Grant](https://tools.ietf.org/html/rfc6749
 **IMPORTANT**: *It is strongly discouraged to store a `clientSecret` on a distributed app. Please refer to [OAuth 2.0 for Native Apps](https://tools.ietf.org/html/draft-ietf-oauth-native-apps-12#section-8.5) for more information.*
 
 ## Authorization
+
 First, update your `AppDelegate` to include the following function to allow the redirect to occur:
 
 ```swift
@@ -127,6 +137,7 @@ OktaAuth.login(username: "user@example.com", password: "password").start(view: s
 ```
 
 ### Handle the Authentication State
+
 Returns `true` if there is a valid access token stored in the TokenManager. This is the best way to determine if a user has successfully authenticated into your app.
 
 ```swift
@@ -136,6 +147,7 @@ if !OktaAuth.isAuthenticated() {
 ```
 
 ### Get UserInfo
+
 Calls the OIDC userInfo endpoint to return user information.
 
 ```swift
@@ -151,6 +163,7 @@ OktaAuth.userinfo() { response, error in
 ```
 
 ### Introspect a Token
+
 Calls the introspection endpoint to inspect the validity of the specified token.
 
 ```swift
@@ -163,7 +176,23 @@ OktaAuth.introspect().validate(token: token)
 }
 ```
 
+### Refresh a Token
+
+Since access tokens are traditionally short-lived, you can refresh them by using a refresh token. See [configuration](#configuration) to ensure your app is configured properly for this flow.
+
+```swift
+OktaAuth.refresh()
+.then { newAccessToken in
+    print(newAccessToken)
+}
+.catch { error in
+    // Error
+}
+
+```
+
 ### Revoke a Token
+
 Calls the revocation endpoint to revoke the specified token.
 
 ```swift
@@ -178,6 +207,7 @@ OktaAuth.revoke(token: token) { response, error in
 ```
 
 ### Token Management
+
 Tokens are securely stored in the Keychain and can be retrieved from the TokenManager.
 
 ```swift
@@ -189,6 +219,7 @@ OktaAuth.tokens?.refreshToken
 ## Development
 
 ### Running Tests
+
 To perform an end-to-end test, update the `Okta.plist` file to match your configuration as specified in the [prerequisites](#prerequisites). Next, export the following environment variables:
 
 ```bash
@@ -202,4 +233,5 @@ bash ./scripts/build-and-test.sh
 **Note:** *You may need to update the emulator device to match your Xcode version*
 
 ## License
+
 Okta is available under the Apache 2.0 license. See the LICENSE file for more info.


### PR DESCRIPTION
- Before tokens are returned via the TokenManger, they are checked against their expiration time.
- Expose `Refresh` abilities for tokens