### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ if !OktaAuth.isAuthenticated() {
 Calls the OIDC userInfo endpoint to return user information.
 
 ```swift
-OktaAuth.userinfo() { response, error in
+OktaAuth.getUser() { response, error in
     if error != nil {
         print("Error: \(error!)")
     }


### PR DESCRIPTION
### Description

Brings in changes from #62 to run internal tests

> Fixed README incorrectly referencing a function called `userinfo` which in reality is named `getUser`