### PR TITLE
:bug: Fixes issue where tokenManager instance was not being created

### DIFF
--- a/Example/Tests/TestUtils.swift
+++ b/Example/Tests/TestUtils.swift
@@ -55,12 +55,12 @@ struct TestUtils {
         let mockTokenResponse = OIDTokenResponse(
             request: mockTokenRequest,
             parameters: [
-                "access_token": mockAccessToken as NSCopying & NSObjectProtocol,
-                "expires_in": expiresIn as NSCopying & NSObjectProtocol,
-                "token_type": "Bearer" as NSCopying & NSObjectProtocol,
-                "id_token": mockIdToken as NSCopying & NSObjectProtocol,
+                 "access_token": mockAccessToken as NSCopying & NSObjectProtocol,
+                   "expires_in": expiresIn as NSCopying & NSObjectProtocol,
+                   "token_type": "Bearer" as NSCopying & NSObjectProtocol,
+                     "id_token": mockIdToken as NSCopying & NSObjectProtocol,
                 "refresh_token": mockRefreshToken as NSCopying & NSObjectProtocol,
-                "scope": mockScopes as NSCopying & NSObjectProtocol
+                        "scope": mockScopes as NSCopying & NSObjectProtocol
             ]
         )
 

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -279,7 +279,7 @@ class Tests: XCTestCase {
 
         OktaAuth.refresh()
         .catch { error in
-            XCTAssertEqual(error.localizedDescription, OktaError.NoRefreshToken.localizedDescription)
+            XCTAssertEqual(error.localizedDescription, OktaError.NoTokens.localizedDescription)
             refreshExpectation.fulfill()
         }
 

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -5,6 +5,8 @@ import AppAuth
 import Vinculum
 
 class Tests: XCTestCase {
+    let TOKEN_EXPIRATION_WAIT: UInt32 = 5
+
     override func setUp() {
         super.setUp()
     }
@@ -208,9 +210,9 @@ class Tests: XCTestCase {
         waitForIt(10)
 
         OktaAuth.tokens?.validationOptions["exp"] = true
-        // Wait for the token to expire and update validation options
-        // to check for expiration
-        sleep(5)
+
+        // Wait for tokens to expire and update validation options to check for expiration
+        sleep(TOKEN_EXPIRATION_WAIT)
 
         XCTAssertEqual(OktaAuth.tokens?.accessToken, nil)
         XCTAssertEqual(OktaAuth.tokens?.idToken, nil)
@@ -266,8 +268,8 @@ class Tests: XCTestCase {
 
         waitForIt()
 
-        // Wait for token to expire
-        sleep(5)
+        // Wait for tokens to expire
+        sleep(TOKEN_EXPIRATION_WAIT)
 
         let isAuth = OktaAuth.isAuthenticated()
         XCTAssertFalse(isAuth)
@@ -333,7 +335,7 @@ class Tests: XCTestCase {
         waitForIt()
 
         // Wait for tokens to expire
-        sleep(3)
+        sleep(TOKEN_EXPIRATION_WAIT)
 
         // Re-store the authState
         OktaAuthorization().storeAuthState(OktaAuth.tokens!)

--- a/Okta/OktaError.swift
+++ b/Okta/OktaError.swift
@@ -23,6 +23,7 @@ public enum OktaError: Error {
     case NoPListGiven
     case NoRefreshToken
     case NoRevocationEndpoint
+    case NoTokens
     case NoUserCredentials
     case NoUserInfoEndpoint
     case ParseFailure
@@ -59,6 +60,8 @@ extension OktaError: LocalizedError {
             return NSLocalizedString("No refresh token stored. Make sure the 'offline_access' scope is included in your PList.", comment: "")
         case .NoRevocationEndpoint:
             return NSLocalizedString("Error finding the revocation endpoint.", comment: "")
+        case .NoTokens:
+            return NSLocalizedString("No tokens stored in the token manager.", comment: "")
         case .NoUserCredentials:
             return NSLocalizedString("User credentials not included.", comment: "")
         case .NoUserInfoEndpoint:

--- a/Okta/OktaRefresh.swift
+++ b/Okta/OktaRefresh.swift
@@ -45,6 +45,8 @@ internal struct Refresh {
                 guard let token = accessToken else {
                     return reject(OktaError.ErrorFetchingFreshTokens("Access Token could not be refreshed."))
                 }
+                // Re-store the authState on token refreshing
+                OktaAuthorization().storeAuthState(tokens!)
                 return resolve(token)
             })
         })

--- a/Okta/OktaTokenManager.swift
+++ b/Okta/OktaTokenManager.swift
@@ -15,8 +15,6 @@ import Vinculum
 
 open class OktaTokenManager: NSObject, NSCoding {
 
-    internal var _idToken: String? = nil
-
     open var authState: OIDAuthState
     open var config: [String: String]
     open var accessibility: CFString
@@ -36,22 +34,21 @@ open class OktaTokenManager: NSObject, NSCoding {
     }
 
     open var idToken: String? {
-        // Return the known idToken via the internal _idToken var
-        // since it gets lost on refresh
+        // Return the known idToken if it is valid
         get {
-            guard let token = self._idToken else { return nil }
-            var returnToken: String?
+            guard let tokenResponse = self.authState.lastTokenResponse,
+                let token = tokenResponse.idToken else {
+                    return nil
+            }
             do {
-                let isValid = try isValidToken(idToken: token)
-                if isValid {
-                    returnToken = token
-                }
+                // Attempt to validate the token
+                let valid = try isValidToken(idToken: token)
+                return valid ? token : nil
             } catch let error {
                 // Capture the error here since we aren't throwing
                 print(error)
-                returnToken = nil
+                return nil
             }
-            return returnToken
         }
     }
 
@@ -83,27 +80,6 @@ open class OktaTokenManager: NSObject, NSCoding {
         }
 
         super.init()
-
-        // Since the idToken isn't stored in the last tokenResponse after refresh,
-        // refer to the cached keychain version.
-        if let prevIdToken = authState.lastTokenResponse?.idToken {
-            // Validate the token before storing it
-            do {
-                let isValid = try isValidToken(idToken: prevIdToken)
-                if isValid {
-                    self._idToken = prevIdToken
-                    try? Vinculum.set(key: "idToken", value: prevIdToken)
-                }
-            } catch let error {
-                throw error
-            }
-        } else {
-            guard let prevIdToken = try? Vinculum.get("idToken")?.getString() else {
-                self._idToken = nil
-                return
-            }
-            self._idToken = prevIdToken
-        }
 
         // Store the current configuration
         OktaAuth.configuration = config


### PR DESCRIPTION
### Description

On successful authentication, the user's auth context is serialized so it can be resumed in the future. Upon an application's resumed state, an attempt to deserialize the stored data is made, including re-initializing the `TokenManager` object. Oftentimes tokens are expired when attempting to resume state, which caused the constructor to fail and throw an exception.

This PR contains a fix for the above issue, removing token validation when initializing the `TokenManager`, **only** validating the token on attempted used.

### Resolves
- #64 
- [OKTA-184308](https://oktainc.atlassian.net/browse/OKTA-184308)



