### PR TITLE
OKTA-211992 Remove HydraAsync from public API

### DIFF
--- a/Okta/OktaAuth/OktaAuth.swift
+++ b/Okta/OktaAuth/OktaAuth.swift
@@ -155,21 +155,20 @@ public struct OktaAuthorization {
                 return reject(OktaError.noDiscoveryEndpoint)
             }
 
-            OktaApi.get(configUrl, headers: nil)
-            .then { response in
+            OktaApi.get(configUrl, headers: nil, onSuccess: { response in
                 guard let dictResponse = response, let oidcConfig = try? OIDServiceDiscovery(dictionary: dictResponse) else {
-                    return reject(OktaError.parseFailure)
+                    reject(OktaError.parseFailure)
+                    return
                 }
                 // Cache the well-known endpoint response
                 OktaAuth.wellKnown = dictResponse
-                return resolve(OIDServiceConfiguration(discoveryDocument: oidcConfig))
-            }
-            .catch { error in
+                resolve(OIDServiceConfiguration(discoveryDocument: oidcConfig))
+            }, onError: { error in
                 let responseError =
                     "Error returning discovery document: \(error.localizedDescription) Please" +
                     "check your PList configuration"
-                return reject(OktaError.APIError(responseError))
-            }
+                reject(OktaError.APIError(responseError))
+            })
         })
     }
 

--- a/Okta/OktaAuth/OktaIntrospection.swift
+++ b/Okta/OktaAuth/OktaIntrospection.swift
@@ -29,14 +29,15 @@ public struct Introspect {
 
             let data = "token=\(token)&client_id=\(OktaAuth.configuration?["clientId"] as! String)"
 
-            OktaApi.post(introspectionEndpoint, headers: headers, postString: data)
-            .then { response in
+            OktaApi.post(introspectionEndpoint, headers: headers, postString: data, onSuccess: { response in
                 guard let isActive = response?["active"] as? Bool else {
-                    return reject(OktaError.parseFailure)
+                    reject(OktaError.parseFailure)
+                    return
                 }
-                return resolve(isActive)
-            }
-            .catch { error in reject(OktaError.noIntrospectionEndpoint) }
+                resolve(isActive)
+            }, onError: { error in
+                reject(OktaError.noIntrospectionEndpoint)
+            })
         })
     }
 

--- a/Okta/OktaAuth/OktaRevoke.swift
+++ b/Okta/OktaAuth/OktaRevoke.swift
@@ -31,9 +31,9 @@ public struct Revoke {
 
         let data = "token=\(token)&client_id=\(OktaAuth.configuration?["clientId"] as! String)"
 
-        OktaApi.post(revokeEndpoint, headers: headers, postString: data)
-        .then { response in callback(response, nil) }
-        .catch { error in callback(nil, error as? OktaError) }
+        OktaApi.post(revokeEndpoint, headers: headers, postString: data,
+            onSuccess: { response in callback(response, nil)},
+            onError: { error in callback(nil, error) })
     }
 
     func getRevokeEndpoint() -> URL? {

--- a/Okta/OktaAuth/OktaUserInfo.swift
+++ b/Okta/OktaAuth/OktaUserInfo.swift
@@ -30,9 +30,9 @@ internal struct UserInfo {
             "Authorization": "Bearer \(token)"
         ]
 
-        OktaApi.post(userInfoEndpoint, headers: headers, postData: nil)
-        .then { response in callback(response, nil) }
-        .catch { error in callback(nil, error as? OktaError) }
+        OktaApi.post(userInfoEndpoint, headers: headers, postData: nil,
+            onSuccess: { response in callback(response, nil)},
+            onError: { error in callback(nil, error) })
     }
 
     func getUserInfoEndpoint() -> URL? {


### PR DESCRIPTION
### Problem Analysis (Technical)
First step in removing HydraAsync dependency is to rework class responsible for network requests to Okta API. This will facilitate separation of further work into several patches.

### Solution (Technical)
Reworked OktaAPI class to omit using Hydra async.

### Affected Components
Revoke, Introspect, GetUserInfo, SignIn, SignOut functionality.

### Tests
UI tests