### PR TITLE
OKTA-218175 AppAuth iOS: Save AuthState object to keychain with composite key

### DIFF
--- a/Example/Okta/ViewController.swift
+++ b/Example/Okta/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var signInButton: UIButton!
     
     private var oktaAppAuth: OktaAppAuth?
-    private var authStateManager: OktaAuthStateManager? = OktaAuthStateManager.readFromSecureStorage() {
+    private var authStateManager: OktaAuthStateManager? {
         didSet {
             oldValue?.clear()
             authStateManager?.writeToSecureStorage()
@@ -40,6 +40,10 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         oktaAppAuth = try? OktaAppAuth(configuration: isUITest ? testConfig : nil)
         AppDelegate.shared.oktaAuth = oktaAppAuth
+        
+        if let config = oktaAppAuth?.configuration {
+            authStateManager = OktaAuthStateManager.readFromSecureStorage(for: config)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Example/Tests/OktaAuthTokenManagerTests.swift
+++ b/Example/Tests/OktaAuthTokenManagerTests.swift
@@ -179,4 +179,36 @@ class OktaAuthTokenManagerTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+    
+    func testReadWriteToSecureStorage() {
+        guard let testConfig = try? OktaAuthConfig(with: [
+            "clientId" : TestUtils.mockClientId,
+            "issuer" : TestUtils.mockIssuer,
+            "scopes" : "test",
+            "redirectUri" : "http://test"
+        ]) else {
+            XCTFail("Unable to create test config")
+            return
+        }
+        
+        let manager = TestUtils.authStateManager()
+        
+        XCTAssertNil(OktaAuthStateManager.readFromSecureStorage(for: testConfig))
+        
+        manager.writeToSecureStorage()
+        
+        let storedManager = OktaAuthStateManager.readFromSecureStorage(for: testConfig)
+        XCTAssertNotNil(storedManager)
+        XCTAssertEqual(
+            storedManager?.authState.lastAuthorizationResponse.accessToken,
+            manager.authState.lastAuthorizationResponse.accessToken
+        )
+        XCTAssertEqual(
+            storedManager?.authState.lastAuthorizationResponse.idToken,
+            manager.authState.lastAuthorizationResponse.idToken
+        )
+        
+        manager.clear()
+        XCTAssertNil(OktaAuthStateManager.readFromSecureStorage(for: testConfig))
+    }
 }

--- a/Okta/OktaAuth/OktaAuthStateManager.swift
+++ b/Okta/OktaAuth/OktaAuthStateManager.swift
@@ -157,8 +157,6 @@ open class OktaAuthStateManager: NSObject, NSCoding {
 }
 
 public extension OktaAuthStateManager {
-
-    private static let legacySecureStorageKey = "OktaAuthStateManager"
     
     class func storageKey(clientId: String, issuer: String?) -> String {
         guard let issuer = issuer else {
@@ -169,7 +167,7 @@ public extension OktaAuthStateManager {
     }
     
     class func readFromSecureStorage() -> OktaAuthStateManager? {
-        return readFromSecureStorage(forKey: legacySecureStorageKey)
+        return readFromSecureStorage(forKey: "OktaAuthStateManager")
     }
 
     class func readFromSecureStorage(for config: OktaAuthConfig) -> OktaAuthStateManager? {

--- a/Okta/OktaAuth/OktaAuthStateManager.swift
+++ b/Okta/OktaAuth/OktaAuthStateManager.swift
@@ -157,6 +157,8 @@ open class OktaAuthStateManager: NSObject, NSCoding {
 }
 
 public extension OktaAuthStateManager {
+
+    private static let legacySecureStorageKey = "OktaAuthStateManager"
     
     class func storageKey(clientId: String, issuer: String?) -> String {
         guard let issuer = issuer else {
@@ -165,18 +167,14 @@ public extension OktaAuthStateManager {
         
         return issuer + "_" + clientId
     }
+    
+    class func readFromSecureStorage() -> OktaAuthStateManager? {
+        return readFromSecureStorage(forKey: legacySecureStorageKey)
+    }
 
     class func readFromSecureStorage(for config: OktaAuthConfig) -> OktaAuthStateManager? {
         let secureStorageKey = storageKey(clientId: config.clientId, issuer: config.issuer)
-        guard let encodedAuthState: Data = try? OktaKeychain.get(key: secureStorageKey) else {
-            return nil
-        }
-
-        guard let state = NSKeyedUnarchiver.unarchiveObject(with: encodedAuthState) as? OktaAuthStateManager else {
-            return nil
-        }
-
-        return state
+        return readFromSecureStorage(forKey: secureStorageKey)
     }
     
     func writeToSecureStorage() {
@@ -191,6 +189,18 @@ public extension OktaAuthStateManager {
         } catch let error {
             print("Error: \(error)")
         }
+    }
+    
+    private class func readFromSecureStorage(forKey secureStorageKey: String) -> OktaAuthStateManager? {
+        guard let encodedAuthState: Data = try? OktaKeychain.get(key: secureStorageKey) else {
+            return nil
+        }
+
+        guard let state = NSKeyedUnarchiver.unarchiveObject(with: encodedAuthState) as? OktaAuthStateManager else {
+            return nil
+        }
+
+        return state
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,29 @@ authStateManager?.idToken
 authStateManager?.refreshToken
 ```
 
-**Note:** Auth state manager stores tokens of the last logged in user. If you need to use OktaAuth SDK to support several clients you should manage OktaAuthStateManager-s returned by `signInWithBrowser` or `authenticate` operation.
+User is responsible for storing OktaAuthStateManager returned by `signInWithBrowser` or `authenticate` operation. To store manager call the `writeToSecureStorage` method:
+
+```swift
+oktaAuth.signInWithBrowser(from: self) { authStateManager, error in
+  authStateManager.writeToSecureStorage()
+}
+```
+
+To retrieve stored manager call `readFromSecureStorage(for: )` and pass here Okta configuration that corresponds to a manager you are interested in.
+
+```swift
+guard let authStateManager = OktaAuthStateManager.readFromSecureStorage(for: oktaConfig) else {
+    // unauthenticated
+}
+
+//authenticated 
+// authStateManager.accessToken
+// authStateManager.idToken
+// authStateManager.refreshToken
+
+```
+
+**Note:** In OktaAppAuth SDK 3.0 we added support for multiple Oauth 2.0 accounts. So developer can use Okta endpoint, social endpoint and others in one application. Therefore `OktaAuthStateManager` is stored in keychain using composite key constructed based on configuration. For backward compatibility there is a method `readFromSecureStorage()` that tries to read `OktaAuthStateManager` stored on a legacy way, so user could retrieve previously stored `OktaAuthStateManager` after switching to a newer version of SDK. 
 
 #### introspect
 


### PR DESCRIPTION
### Problem Analysis (Technical)

In OktaAppAuth SDK 3.0 we will add support for multiple Oauth 2.0 accounts. So developer can use Okta endpoint, social endpoint and others in one application. There is one part in the solution that doesn't look great - using of hardcoded key for storing OktaAuthStateManager instance. This leads to the following issue:
1. OktaAuthStateManager instance for Okta endpoint is saved with hardcoded key - "OktaAuthStateTokenManager"
2. OktaAuthStateManager instance for social endpoint is saved with hardcoded key - "OktaAuthStateTokenManager"
Actual outcome:
OktaAuthStateManager instance for social endpoint overwrites Okta's data in keychain
To cope with that we have to add additional function for storing/retrieving data from keychain. Function should accept custom key for saving. Since OktaAppAuth class is responsible for storing/retrieving OktaAuthStateManager it should also be responsible for generating unique key

### Solution (Technical)

Save AuthState object to keychain with composite key

### Affected Components

Okta Auth SDK

### Tests

UI Tests, OktaAuthSatemanagerTests